### PR TITLE
feat: get share token from amm

### DIFF
--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hydradx-traits"
 description = "Shared traits"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["GalacticCouncil"]
 edition = "2018"
 repository = "https://github.com/galacticcouncil/warehouse/tree/master/traits"

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -49,6 +49,9 @@ pub trait AMM<AccountId, AssetId, AssetPair, Amount: Zero> {
     /// Return pair account.
     fn get_pair_id(assets: AssetPair) -> AccountId;
 
+    /// Return share token for assets.
+    fn get_share_token(assets: AssetPair) -> AssetId;
+
     /// Return list of active assets in a given pool.
     fn get_pool_assets(pool_account_id: &AccountId) -> Option<Vec<AssetId>>;
 


### PR DESCRIPTION
Liquidity mining pallet need to know share token from amm `AssetPair`.