### PR TITLE
feat: introduce new accountidfor + reorganize registry traits

### DIFF
--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-traits"
-version = "0.5.1"
+version = "0.6.0"
 description = "Shared traits"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -19,6 +19,8 @@
 #![allow(clippy::upper_case_acronyms)]
 
 pub mod pools;
+pub mod registry;
+pub use registry::*;
 
 use codec::{Decode, Encode};
 use frame_support::dispatch;
@@ -130,48 +132,6 @@ pub trait Resolver<AccountId, Intention, E> {
     /// Resolve intentions by either directly trading with each other or via AMM pool.
     /// Intention ```intention``` must be validated prior to call this function.
     fn resolve_matched_intentions(pair_account: &AccountId, intention: &Intention, matched: &[&Intention]);
-}
-
-pub trait Registry<AssetId, AssetName, Balance, Error> {
-    fn exists(name: AssetId) -> bool;
-
-    fn retrieve_asset(name: &AssetName) -> Result<AssetId, Error>;
-
-    fn create_asset(name: &AssetName, existential_deposit: Balance) -> Result<AssetId, Error>;
-
-    fn get_or_create_asset(name: AssetName, existential_deposit: Balance) -> Result<AssetId, Error> {
-        if let Ok(asset_id) = Self::retrieve_asset(&name) {
-            Ok(asset_id)
-        } else {
-            Self::create_asset(&name, existential_deposit)
-        }
-    }
-}
-
-pub trait ShareTokenRegistry<AssetId, AssetName, Balance, Error>: Registry<AssetId, AssetName, Balance, Error> {
-    fn retrieve_shared_asset(name: &AssetName, assets: &[AssetId]) -> Result<AssetId, Error>;
-
-    fn create_shared_asset(
-        name: &AssetName,
-        assets: &[AssetId],
-        existential_deposit: Balance,
-    ) -> Result<AssetId, Error>;
-
-    fn get_or_create_shared_asset(
-        name: AssetName,
-        assets: Vec<AssetId>,
-        existential_deposit: Balance,
-    ) -> Result<AssetId, Error> {
-        if let Ok(asset_id) = Self::retrieve_shared_asset(&name, &assets) {
-            Ok(asset_id)
-        } else {
-            Self::create_shared_asset(&name, &assets, existential_deposit)
-        }
-    }
-}
-
-pub trait AssetPairAccountIdFor<AssetId, AccountId> {
-    fn from_assets(asset_a: AssetId, asset_b: AssetId, identifier: &str) -> AccountId;
 }
 
 /// Handler used by AMM pools to perform some tasks when a new pool is created.

--- a/traits/src/registry.rs
+++ b/traits/src/registry.rs
@@ -1,0 +1,55 @@
+use sp_std::vec::Vec;
+
+pub trait Registry<AssetId, AssetName, Balance, Error> {
+    fn exists(name: AssetId) -> bool;
+
+    fn retrieve_asset(name: &AssetName) -> Result<AssetId, Error>;
+
+    fn create_asset(name: &AssetName, existential_deposit: Balance) -> Result<AssetId, Error>;
+
+    fn get_or_create_asset(name: AssetName, existential_deposit: Balance) -> Result<AssetId, Error> {
+        if let Ok(asset_id) = Self::retrieve_asset(&name) {
+            Ok(asset_id)
+        } else {
+            Self::create_asset(&name, existential_deposit)
+        }
+    }
+}
+
+pub trait ShareTokenRegistry<AssetId, AssetName, Balance, Error>: Registry<AssetId, AssetName, Balance, Error> {
+    fn retrieve_shared_asset(name: &AssetName, assets: &[AssetId]) -> Result<AssetId, Error>;
+
+    fn create_shared_asset(
+        name: &AssetName,
+        assets: &[AssetId],
+        existential_deposit: Balance,
+    ) -> Result<AssetId, Error>;
+
+    fn get_or_create_shared_asset(
+        name: AssetName,
+        assets: Vec<AssetId>,
+        existential_deposit: Balance,
+    ) -> Result<AssetId, Error> {
+        if let Ok(asset_id) = Self::retrieve_shared_asset(&name, &assets) {
+            Ok(asset_id)
+        } else {
+            Self::create_shared_asset(&name, &assets, existential_deposit)
+        }
+    }
+}
+
+#[deprecated(since = "0.6.0", note = "Please use `AccountIdFor` instead")]
+pub trait AssetPairAccountIdFor<AssetId, AccountId> {
+    fn from_assets(asset_a: AssetId, asset_b: AssetId, identifier: &str) -> AccountId;
+}
+
+/// Abstraction over account id and account name creation for `Assets`
+pub trait AccountIdFor<Assets> {
+    type AccountId;
+
+    /// Create account id for given assets and an identifier
+    fn from_assets(assets: &Assets, identifier: Option<&str>) -> Self::AccountId;
+
+    /// Create a name to uniquely identify a share account id for given assets and an identifier.
+    fn name(assets: &Assets, identifier: Option<&str>) -> Vec<u8>;
+}

--- a/traits/src/registry.rs
+++ b/traits/src/registry.rs
@@ -50,6 +50,6 @@ pub trait AccountIdFor<Assets> {
     /// Create account id for given assets and an identifier
     fn from_assets(assets: &Assets, identifier: Option<&str>) -> Self::AccountId;
 
-    /// Create a name to uniquely identify a share account id for given assets and an identifier.
+    /// Create a name to uniquely identify given `assets`.
     fn name(assets: &Assets, identifier: Option<&str>) -> Vec<u8>;
 }


### PR DESCRIPTION
Replace Current "ShareAccountIdFor" with improved version where it can handle more than 2 assets.

This might be eventually needed for Stableswap with more than 2 assets in pool. 