### PR TITLE
Add types to set tx fee asset on new account

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,15 @@ members = [
 ]
 
 resolver = "2"
+
+[patch."https://github.com/open-web3-stack/open-runtime-module-library"]
+orml-currencies = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
+orml-tokens = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
+orml-traits = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
+orml-vesting = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
+orml-benchmarking = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17", optional = true }
+orml-xtokens = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
+orml-xcm-support = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
+orml-unknown-tokens = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
+orml-xcm = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
+orml-utilities = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = [
 
 resolver = "2"
 
+# Use a fork of ORML until we are using a version that includes
+# https://github.com/open-web3-stack/open-runtime-module-library/pull/754
 [patch."https://github.com/open-web3-stack/open-runtime-module-library"]
 orml-currencies = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
 orml-tokens = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,4 @@ resolver = "2"
 orml-currencies = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
 orml-tokens = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
 orml-traits = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
-orml-vesting = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
-orml-benchmarking = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17", optional = true }
-orml-xtokens = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
-orml-xcm-support = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
-orml-unknown-tokens = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
-orml-xcm = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }
 orml-utilities = { git = "https://github.com/apopiak/open-runtime-module-library", branch = "apopiak/on-new-account-9-17" }

--- a/collator-rewards/Cargo.toml
+++ b/collator-rewards/Cargo.toml
@@ -11,35 +11,35 @@ repository = "https://github.com/galacticcouncil/warehouse"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
 
 [dependencies]
 log = { default-features = false, version = "0.4.16" }
 codec = { default-features = false, features = ["derive"], package = "parity-scale-codec", version = "2.3.1" }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, version = "1.0.136" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 
 # ORML dependencies
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 
 # Optionals
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false, optional = true }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false, optional = true }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false, optional = true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false, optional = true }
 
 [dev-dependencies]
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
-pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
+pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 
 [features]
 default = ["std"]

--- a/collator-rewards/src/mock.rs
+++ b/collator-rewards/src/mock.rs
@@ -99,6 +99,8 @@ impl orml_tokens::Config for Test {
     type OnDust = ();
     type MaxLocks = ();
     type DustRemovalWhitelist = Nothing;
+    type OnNewTokenAccount = ();
+    type OnKilledTokenAccount = ();
 }
 
 parameter_types! {

--- a/faucet/src/mock.rs
+++ b/faucet/src/mock.rs
@@ -95,6 +95,8 @@ impl orml_tokens::Config for Test {
     type OnDust = ();
     type MaxLocks = ();
     type DustRemovalWhitelist = Nothing;
+    type OnNewTokenAccount = ();
+    type OnKilledTokenAccount = ();
 }
 
 impl Config for Test {

--- a/transaction-multi-payment/src/lib.rs
+++ b/transaction-multi-payment/src/lib.rs
@@ -603,7 +603,8 @@ impl<T: Config> Happened<(T::AccountId, AssetIdOf<T>)> for AddTxAssetOnAccount<T
 
 /// Type to automatically remove the fee currency for an account on account deletion.
 ///
-/// Note: The fee currency is only removed if the system account is gone.
+/// Note: The fee currency is only removed if the system account is gone or the account
+/// corresponding to the fee currency is empty.
 pub struct RemoveTxAssetOnKilled<T>(PhantomData<T>);
 impl<T: Config> Happened<(T::AccountId, AssetIdOf<T>)> for RemoveTxAssetOnKilled<T> {
     fn happened((who, _currency): &(T::AccountId, AssetIdOf<T>)) {

--- a/transaction-multi-payment/src/lib.rs
+++ b/transaction-multi-payment/src/lib.rs
@@ -593,10 +593,10 @@ impl<T: Config + Send + Sync> CurrencyBalanceCheck<T> {
 pub struct AddTxAssetOnAccount<T>(PhantomData<T>);
 impl<T: Config> Happened<(T::AccountId, AssetIdOf<T>)> for AddTxAssetOnAccount<T> {
     fn happened((who, currency): &(T::AccountId, AssetIdOf<T>)) {
-        if !AccountCurrencyMap::<T>::contains_key(&who)
+        if !AccountCurrencyMap::<T>::contains_key(who)
             && (*currency == T::NativeAssetId::get() || AcceptedCurrencies::<T>::contains_key(&currency))
         {
-            AccountCurrencyMap::<T>::insert(&who, currency);
+            AccountCurrencyMap::<T>::insert(who, currency);
         }
     }
 }
@@ -608,12 +608,12 @@ impl<T: Config> Happened<(T::AccountId, AssetIdOf<T>)> for AddTxAssetOnAccount<T
 pub struct RemoveTxAssetOnKilled<T>(PhantomData<T>);
 impl<T: Config> Happened<(T::AccountId, AssetIdOf<T>)> for RemoveTxAssetOnKilled<T> {
     fn happened((who, _currency): &(T::AccountId, AssetIdOf<T>)) {
-        if !frame_system::Pallet::<T>::account_exists(&who) {
-            AccountCurrencyMap::<T>::remove(&who);
+        if !frame_system::Pallet::<T>::account_exists(who) {
+            AccountCurrencyMap::<T>::remove(who);
         } else {
-            if let Some(currency) = AccountCurrencyMap::<T>::get(&who) {
-                if T::Currencies::total_balance(currency, &who).is_zero() {
-                    AccountCurrencyMap::<T>::remove(&who);
+            if let Some(currency) = AccountCurrencyMap::<T>::get(who) {
+                if T::Currencies::total_balance(currency, who).is_zero() {
+                    AccountCurrencyMap::<T>::remove(who);
                 }
             }
         }

--- a/transaction-multi-payment/src/lib.rs
+++ b/transaction-multi-payment/src/lib.rs
@@ -609,6 +609,12 @@ impl<T: Config> Happened<(T::AccountId, AssetIdOf<T>)> for RemoveTxAssetOnKilled
     fn happened((who, _currency): &(T::AccountId, AssetIdOf<T>)) {
         if !frame_system::Pallet::<T>::account_exists(&who) {
             AccountCurrencyMap::<T>::remove(&who);
+        } else {
+            if let Some(currency) = AccountCurrencyMap::<T>::get(&who) {
+                if T::Currencies::total_balance(currency, &who).is_zero() {
+                    AccountCurrencyMap::<T>::remove(&who);
+                }
+            }
         }
     }
 }

--- a/transaction-multi-payment/src/lib.rs
+++ b/transaction-multi-payment/src/lib.rs
@@ -610,11 +610,9 @@ impl<T: Config> Happened<(T::AccountId, AssetIdOf<T>)> for RemoveTxAssetOnKilled
     fn happened((who, _currency): &(T::AccountId, AssetIdOf<T>)) {
         if !frame_system::Pallet::<T>::account_exists(who) {
             AccountCurrencyMap::<T>::remove(who);
-        } else {
-            if let Some(currency) = AccountCurrencyMap::<T>::get(who) {
-                if T::Currencies::total_balance(currency, who).is_zero() {
-                    AccountCurrencyMap::<T>::remove(who);
-                }
+        } else if let Some(currency) = AccountCurrencyMap::<T>::get(who) {
+            if T::Currencies::total_balance(currency, who).is_zero() {
+                AccountCurrencyMap::<T>::remove(who);
             }
         }
     }

--- a/transaction-multi-payment/src/mock.rs
+++ b/transaction-multi-payment/src/mock.rs
@@ -53,6 +53,9 @@ pub const SUPPORTED_CURRENCY: AssetId = 2000;
 pub const SUPPORTED_CURRENCY_WITH_PRICE: AssetId = 3000;
 pub const UNSUPPORTED_CURRENCY: AssetId = 4000;
 pub const SUPPORTED_CURRENCY_NO_BALANCE: AssetId = 5000; // Used for insufficient balance testing
+pub const HIGH_ED_CURRENCY: AssetId = 6000;
+
+pub const HIGH_ED: Balance = 5;
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 const MAX_BLOCK_WEIGHT: Weight = 1024;
@@ -208,8 +211,11 @@ impl SpotPriceProvider<AssetId> for SpotPrice {
 }
 
 parameter_type_with_key! {
-    pub ExistentialDeposits: |_currency_id: AssetId| -> Balance {
-        One::one()
+    pub ExistentialDeposits: |currency_id: AssetId| -> Balance {
+        match currency_id {
+            &HIGH_ED_CURRENCY => HIGH_ED,
+            _ => One::one(),
+        }
     };
 }
 
@@ -223,6 +229,8 @@ impl orml_tokens::Config for Test {
     type OnDust = ();
     type MaxLocks = ();
     type DustRemovalWhitelist = Nothing;
+    type OnNewTokenAccount = AddTxAssetOnAccount<Test>;
+    type OnKilledTokenAccount = RemoveTxAssetOnKilled<Test>;
 }
 
 impl orml_currencies::Config for Test {
@@ -304,6 +312,7 @@ impl ExtBuilder {
                 (SUPPORTED_CURRENCY_NO_BALANCE, Price::from(1)),
                 (SUPPORTED_CURRENCY, Price::from_float(1.5)),
                 (SUPPORTED_CURRENCY_WITH_PRICE, Price::from_float(0.5)),
+                (HIGH_ED_CURRENCY, Price::from(3)),
             ],
             fallback_account: Some(FALLBACK_ACCOUNT),
             account_currencies: self.account_currencies,

--- a/transaction-multi-payment/src/mock.rs
+++ b/transaction-multi-payment/src/mock.rs
@@ -216,7 +216,7 @@ parameter_type_with_key! {
     pub ExistentialDeposits: |currency_id: AssetId| -> Balance {
         match currency_id {
             &HIGH_ED_CURRENCY => HIGH_ED,
-            _ => One::one() + One::one(),
+            _ => 2u128
         }
     };
 }

--- a/transaction-multi-payment/src/tests.rs
+++ b/transaction-multi-payment/src/tests.rs
@@ -536,7 +536,6 @@ fn set_and_remove_currency_on_lifecycle_callbacks() {
                 false
             ));
             assert_eq!(PaymentPallet::get_currency(BOB), None);
-
         });
 }
 
@@ -560,22 +559,12 @@ fn currency_stays_around_until_reaping() {
 
             // currency is not removed when account goes below existential deposit but stays around
             // until the account is reaped
-            assert_ok!(Tokens::transfer(
-                Some(DAVE).into(),
-                BOB,
-                HIGH_ED_CURRENCY,
-                HIGH_ED + 1,
-            ));
+            assert_ok!(Tokens::transfer(Some(DAVE).into(), BOB, HIGH_ED_CURRENCY, HIGH_ED + 1,));
             assert_eq!(PaymentPallet::get_currency(DAVE), Some(HIGH_ED_CURRENCY));
             assert_eq!(PaymentPallet::get_currency(BOB), Some(HIGH_ED_CURRENCY));
 
             // ... and account is reaped when all funds are transferred
-            assert_ok!(Tokens::transfer_all(
-                Some(DAVE).into(),
-                BOB,
-                HIGH_ED_CURRENCY,
-                false
-            ));
+            assert_ok!(Tokens::transfer_all(Some(DAVE).into(), BOB, HIGH_ED_CURRENCY, false));
             assert_eq!(PaymentPallet::get_currency(DAVE), None);
         });
 }
@@ -633,6 +622,11 @@ fn currency_is_not_changed_on_unrelated_account_activity() {
             assert_ok!(Tokens::transfer(Some(CHARLIE).into(), DAVE, SUPPORTED_CURRENCY, 2));
             assert_eq!(PaymentPallet::get_currency(DAVE), Some(SUPPORTED_CURRENCY_WITH_PRICE));
             // tx fee currency is not removed when an unrelated account is removed
-            assert_ok!(Tokens::transfer_all(Some(DAVE).into(), CHARLIE, SUPPORTED_CURRENCY, false));
+            assert_ok!(Tokens::transfer_all(
+                Some(DAVE).into(),
+                CHARLIE,
+                SUPPORTED_CURRENCY,
+                false
+            ));
         });
 }

--- a/transaction-multi-payment/src/tests.rs
+++ b/transaction-multi-payment/src/tests.rs
@@ -630,3 +630,22 @@ fn currency_is_not_changed_on_unrelated_account_activity() {
             ));
         });
 }
+
+#[test]
+fn only_set_fee_currency_for_supported_currency() {
+    const CHARLIE: AccountId = 5;
+
+    ExtBuilder::default()
+        .base_weight(5)
+        .account_native_balance(CHARLIE, 10)
+        .account_tokens(CHARLIE, UNSUPPORTED_CURRENCY, 10)
+        .build()
+        .execute_with(|| {
+            assert_ok!(Tokens::transfer(Some(CHARLIE).into(), BOB, UNSUPPORTED_CURRENCY, 5));
+
+            assert_eq!(Currencies::free_balance(UNSUPPORTED_CURRENCY, &CHARLIE), 5);
+            assert_eq!(Currencies::free_balance(UNSUPPORTED_CURRENCY, &BOB), 5);
+            // Bob's fee currency was set on transfer (due to account creation)
+            assert_eq!(PaymentPallet::get_currency(BOB), None);
+        });
+}

--- a/transaction-multi-payment/src/tests.rs
+++ b/transaction-multi-payment/src/tests.rs
@@ -512,11 +512,8 @@ fn withdraw_should_not_work() {
 }
 
 #[test]
-fn set_currency_on_account_creation() {
+fn set_and_remove_currency_on_lifecycle_callbacks() {
     const CHARLIE: AccountId = 5;
-    const DAVE: AccountId = 6;
-
-    use frame_support::traits::fungibles::Balanced;
 
     ExtBuilder::default()
         .base_weight(5)
@@ -540,16 +537,35 @@ fn set_currency_on_account_creation() {
             ));
             assert_eq!(PaymentPallet::get_currency(BOB), None);
 
+        });
+}
+
+#[test]
+fn currency_stays_around_until_reaping() {
+    const CHARLIE: AccountId = 5;
+    const DAVE: AccountId = 6;
+
+    use frame_support::traits::fungibles::Balanced;
+
+    ExtBuilder::default()
+        .base_weight(5)
+        .account_native_balance(CHARLIE, 10)
+        .account_tokens(CHARLIE, SUPPORTED_CURRENCY, 10)
+        .build()
+        .execute_with(|| {
+            // setup
             assert_ok!(<Tokens as Balanced<AccountId>>::deposit(HIGH_ED_CURRENCY, &DAVE, HIGH_ED * 2).map(|_| ()));
             assert_eq!(Currencies::free_balance(HIGH_ED_CURRENCY, &DAVE), HIGH_ED * 2);
             assert_eq!(PaymentPallet::get_currency(DAVE), Some(HIGH_ED_CURRENCY));
+
+            // currency is not removed when account goes below existential deposit but stays around
+            // until the account is reaped
             assert_ok!(Tokens::transfer(
                 Some(DAVE).into(),
                 BOB,
                 HIGH_ED_CURRENCY,
                 HIGH_ED + 1,
             ));
-            // currency stays around until the account is reaped
             assert_eq!(PaymentPallet::get_currency(DAVE), Some(HIGH_ED_CURRENCY));
             assert_eq!(PaymentPallet::get_currency(BOB), Some(HIGH_ED_CURRENCY));
 
@@ -561,5 +577,62 @@ fn set_currency_on_account_creation() {
                 false
             ));
             assert_eq!(PaymentPallet::get_currency(DAVE), None);
+        });
+}
+
+#[test]
+fn currency_is_removed_when_balance_hits_zero() {
+    const CHARLIE: AccountId = 5;
+    const DAVE: AccountId = 6;
+
+    use frame_support::traits::fungibles::Balanced;
+
+    ExtBuilder::default()
+        .base_weight(5)
+        .account_native_balance(CHARLIE, 10)
+        .account_tokens(CHARLIE, SUPPORTED_CURRENCY, 10)
+        .build()
+        .execute_with(|| {
+            // setup
+            assert_ok!(<Tokens as Balanced<AccountId>>::deposit(SUPPORTED_CURRENCY_WITH_PRICE, &DAVE, 10).map(|_| ()));
+            assert_eq!(Currencies::free_balance(SUPPORTED_CURRENCY_WITH_PRICE, &DAVE), 10);
+            assert_eq!(PaymentPallet::get_currency(DAVE), Some(SUPPORTED_CURRENCY_WITH_PRICE));
+
+            // currency is removed when all funds of tx fee currency are transferred (even if
+            // account still has other funds)
+            assert_ok!(Tokens::transfer(Some(CHARLIE).into(), DAVE, SUPPORTED_CURRENCY, 2));
+            assert_ok!(Tokens::transfer_all(
+                Some(DAVE).into(),
+                BOB,
+                SUPPORTED_CURRENCY_WITH_PRICE,
+                false
+            ));
+            assert_eq!(PaymentPallet::get_currency(DAVE), None);
+        });
+}
+
+#[test]
+fn currency_is_not_changed_on_unrelated_account_activity() {
+    const CHARLIE: AccountId = 5;
+    const DAVE: AccountId = 6;
+
+    use frame_support::traits::fungibles::Balanced;
+
+    ExtBuilder::default()
+        .base_weight(5)
+        .account_native_balance(CHARLIE, 10)
+        .account_tokens(CHARLIE, SUPPORTED_CURRENCY, 10)
+        .build()
+        .execute_with(|| {
+            // setup
+            assert_ok!(<Tokens as Balanced<AccountId>>::deposit(SUPPORTED_CURRENCY_WITH_PRICE, &DAVE, 10).map(|_| ()));
+            assert_eq!(Currencies::free_balance(SUPPORTED_CURRENCY_WITH_PRICE, &DAVE), 10);
+            assert_eq!(PaymentPallet::get_currency(DAVE), Some(SUPPORTED_CURRENCY_WITH_PRICE));
+
+            // tx fee currency is not changed when a new currency is added to the account
+            assert_ok!(Tokens::transfer(Some(CHARLIE).into(), DAVE, SUPPORTED_CURRENCY, 2));
+            assert_eq!(PaymentPallet::get_currency(DAVE), Some(SUPPORTED_CURRENCY_WITH_PRICE));
+            // tx fee currency is not removed when an unrelated account is removed
+            assert_ok!(Tokens::transfer_all(Some(DAVE).into(), CHARLIE, SUPPORTED_CURRENCY, false));
         });
 }

--- a/transaction-multi-payment/src/tests.rs
+++ b/transaction-multi-payment/src/tests.rs
@@ -621,6 +621,7 @@ fn currency_is_not_changed_on_unrelated_account_activity() {
             // tx fee currency is not changed when a new currency is added to the account
             assert_ok!(Tokens::transfer(Some(CHARLIE).into(), DAVE, SUPPORTED_CURRENCY, 2));
             assert_eq!(PaymentPallet::get_currency(DAVE), Some(SUPPORTED_CURRENCY_WITH_PRICE));
+
             // tx fee currency is not removed when an unrelated account is removed
             assert_ok!(Tokens::transfer_all(
                 Some(DAVE).into(),
@@ -628,6 +629,7 @@ fn currency_is_not_changed_on_unrelated_account_activity() {
                 SUPPORTED_CURRENCY,
                 false
             ));
+            assert_eq!(PaymentPallet::get_currency(DAVE), Some(SUPPORTED_CURRENCY_WITH_PRICE));
         });
 }
 

--- a/transaction-multi-payment/src/tests.rs
+++ b/transaction-multi-payment/src/tests.rs
@@ -645,7 +645,7 @@ fn only_set_fee_currency_for_supported_currency() {
 
             assert_eq!(Currencies::free_balance(UNSUPPORTED_CURRENCY, &CHARLIE), 5);
             assert_eq!(Currencies::free_balance(UNSUPPORTED_CURRENCY, &BOB), 5);
-            // Bob's fee currency was set on transfer (due to account creation)
+            // Bob's fee currency was not set on transfer (due to the currency being unsupported)
             assert_eq!(PaymentPallet::get_currency(BOB), None);
         });
 }


### PR DESCRIPTION
Add structs to the multi tx payment pallet that set and delete tx fee currency on account creation and deletion.

`AddTxAssetOnAccount` sets the tx fee currency on account creation if it is not set already.

`RemoveTxAssetOnKilled` removes the tx fee currency if the system account is removed or if the tx currency balance hits zero.

based on https://github.com/apopiak/open-runtime-module-library/pull/1 (backport of https://github.com/open-web3-stack/open-runtime-module-library/pull/754), we will thus need to maintain a fork of ORML until we're up-to-date in terms of the substrate/polkadot versions
