### PR TITLE
add more MultiCurrencyAdapter tests

### DIFF
--- a/adapters/src/tests.rs
+++ b/adapters/src/tests.rs
@@ -225,12 +225,12 @@ fn can_buy_twice() {
         let mut trader = Trader::new();
 
         let payment1: MultiAsset = (Concrete(core_id.clone()), 1_000_000).into();
-        let res = dbg!(trader.buy_weight(1_000_000, payment1.clone().into()));
+        let res = dbg!(trader.buy_weight(1_000_000, payment1.into()));
         assert!(res
             .expect("buy_weight should succeed because payment == weight")
             .is_empty());
         let payment2: MultiAsset = (Concrete(core_id.clone()), 1_000_000).into();
-        let res = dbg!(trader.buy_weight(1_000_000, payment2.clone().into()));
+        let res = dbg!(trader.buy_weight(1_000_000, payment2.into()));
         assert!(res
             .expect("buy_weight should succeed because payment == weight")
             .is_empty());


### PR DESCRIPTION
Noticed that the coverage for the `MultiCurrencyAdapter` was a bit low and added a few failure case tests.