### PR TITLE
refactor!: removed currency type from NFT

### DIFF
--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-nft"
-version = "2.5.1"
+version = "3.0.0"
 description = "A generic NFT pallet for managing non-fungible tokens"
 authors = ["GalacticCoucil"]
 edition = "2021"

--- a/nft/src/benchmarking.rs
+++ b/nft/src/benchmarking.rs
@@ -35,7 +35,7 @@ fn create_account<T: Config>(name: &'static str, index: u32) -> T::AccountId {
     let caller: T::AccountId = account(name, index, SEED);
 
     let amount = dollar(ENDOWMENT);
-    <T as NFT::Config>::Currency::deposit_creating(&caller, amount.unique_saturated_into());
+    <T as pallet_uniques::Config>::Currency::deposit_creating(&caller, amount.unique_saturated_into());
 
     caller
 }

--- a/nft/src/lib.rs
+++ b/nft/src/lib.rs
@@ -23,7 +23,7 @@ use codec::HasCompact;
 use frame_support::{
     dispatch::DispatchResult,
     ensure,
-    traits::{tokens::nonfungibles::*, Get, NamedReservableCurrency},
+    traits::{tokens::nonfungibles::*, Get},
     transactional, BoundedVec,
 };
 use frame_system::ensure_signed;
@@ -67,7 +67,6 @@ pub mod pallet {
 
     #[pallet::config]
     pub trait Config: frame_system::Config + pallet_uniques::Config {
-        type Currency: NamedReservableCurrency<Self::AccountId, ReserveIdentifier = ReserveIdentifier>;
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
         type WeightInfo: WeightInfo;
         type ProtocolOrigin: EnsureOrigin<Self::Origin>;

--- a/nft/src/mock.rs
+++ b/nft/src/mock.rs
@@ -174,7 +174,7 @@ impl pallet_balances::Config for Test {
     type MaxLocks = ();
     type WeightInfo = ();
     type MaxReserves = MaxReserves;
-    type ReserveIdentifier = ReserveIdentifier;
+    type ReserveIdentifier = ();
 }
 
 pub const ALICE: AccountId = AccountId::new([1u8; 32]);

--- a/nft/src/mock.rs
+++ b/nft/src/mock.rs
@@ -88,8 +88,7 @@ impl NftPermission<ClassType> for NftTestPermissions {
     }
 }
 
-impl pallet_nft::Config for Test {
-    type Currency = Balances;
+impl Config for Test {
     type Event = Event;
     type WeightInfo = pallet_nft::weights::BasiliskWeight<Test>;
     type NftClassId = ClassId;

--- a/nft/src/tests.rs
+++ b/nft/src/tests.rs
@@ -328,10 +328,16 @@ fn deposit_works() {
             <Test as pallet_uniques::Config>::Currency::free_balance(&ALICE),
             initial_balance - class_deposit
         );
-        assert_eq!(<Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE), class_deposit);
+        assert_eq!(
+            <Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE),
+            class_deposit
+        );
 
         assert_ok!(NFTPallet::destroy_class(Origin::signed(ALICE), CLASS_ID_0));
-        assert_eq!(<Test as pallet_uniques::Config>::Currency::free_balance(&ALICE), initial_balance);
+        assert_eq!(
+            <Test as pallet_uniques::Config>::Currency::free_balance(&ALICE),
+            initial_balance
+        );
         assert_eq!(<Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE), 0);
 
         // no deposit
@@ -341,11 +347,17 @@ fn deposit_works() {
             ClassType::LiquidityMining,
             metadata
         ));
-        assert_eq!(<Test as pallet_uniques::Config>::Currency::free_balance(&ALICE), initial_balance);
+        assert_eq!(
+            <Test as pallet_uniques::Config>::Currency::free_balance(&ALICE),
+            initial_balance
+        );
         assert_eq!(<Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE), 0);
 
         assert_ok!(NFTPallet::destroy_class(Origin::signed(ALICE), CLASS_ID_0));
-        assert_eq!(<Test as pallet_uniques::Config>::Currency::free_balance(&ALICE), initial_balance);
+        assert_eq!(
+            <Test as pallet_uniques::Config>::Currency::free_balance(&ALICE),
+            initial_balance
+        );
         assert_eq!(<Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE), 0);
     })
 }

--- a/nft/src/tests.rs
+++ b/nft/src/tests.rs
@@ -314,10 +314,10 @@ fn deposit_works() {
             b"metadata".to_vec().try_into().unwrap();
 
         let class_deposit = <Test as pallet_uniques::Config>::ClassDeposit::get();
-        let initial_balance = <Test as Config>::Currency::free_balance(&ALICE);
+        let initial_balance = <Test as pallet_uniques::Config>::Currency::free_balance(&ALICE);
 
         // has deposit
-        assert_eq!(<Test as Config>::Currency::reserved_balance(&ALICE), 0);
+        assert_eq!(<Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE), 0);
         assert_ok!(NFTPallet::create_class(
             Origin::signed(ALICE),
             CLASS_ID_0,
@@ -325,14 +325,14 @@ fn deposit_works() {
             metadata.clone()
         ));
         assert_eq!(
-            <Test as Config>::Currency::free_balance(&ALICE),
+            <Test as pallet_uniques::Config>::Currency::free_balance(&ALICE),
             initial_balance - class_deposit
         );
-        assert_eq!(<Test as Config>::Currency::reserved_balance(&ALICE), class_deposit);
+        assert_eq!(<Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE), class_deposit);
 
         assert_ok!(NFTPallet::destroy_class(Origin::signed(ALICE), CLASS_ID_0));
-        assert_eq!(<Test as Config>::Currency::free_balance(&ALICE), initial_balance);
-        assert_eq!(<Test as Config>::Currency::reserved_balance(&ALICE), 0);
+        assert_eq!(<Test as pallet_uniques::Config>::Currency::free_balance(&ALICE), initial_balance);
+        assert_eq!(<Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE), 0);
 
         // no deposit
         assert_ok!(NFTPallet::create_class(
@@ -341,12 +341,12 @@ fn deposit_works() {
             ClassType::LiquidityMining,
             metadata
         ));
-        assert_eq!(<Test as Config>::Currency::free_balance(&ALICE), initial_balance);
-        assert_eq!(<Test as Config>::Currency::reserved_balance(&ALICE), 0);
+        assert_eq!(<Test as pallet_uniques::Config>::Currency::free_balance(&ALICE), initial_balance);
+        assert_eq!(<Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE), 0);
 
         assert_ok!(NFTPallet::destroy_class(Origin::signed(ALICE), CLASS_ID_0));
-        assert_eq!(<Test as Config>::Currency::free_balance(&ALICE), initial_balance);
-        assert_eq!(<Test as Config>::Currency::reserved_balance(&ALICE), 0);
+        assert_eq!(<Test as pallet_uniques::Config>::Currency::free_balance(&ALICE), initial_balance);
+        assert_eq!(<Test as pallet_uniques::Config>::Currency::reserved_balance(&ALICE), 0);
     })
 }
 

--- a/nft/src/types.rs
+++ b/nft/src/types.rs
@@ -43,16 +43,6 @@ pub struct InstanceInfo<BoundedVec> {
     pub metadata: BoundedVec,
 }
 
-#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, PartialOrd, Ord, MaxEncodedLen, RuntimeDebug, TypeInfo)]
-#[repr(u8)]
-pub enum ReserveIdentifier {
-    Nft,
-    Marketplace,
-
-    // always the last, indicate number of variants
-    Count,
-}
-
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum ClassType {


### PR DESCRIPTION
as is not used anyway and it was just constraining usable types for other pallets