### PR TITLE
fix: lm valued shares calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-traits"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquidity-mining"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "fixed",
  "frame-support",

--- a/liquidity-mining/Cargo.toml
+++ b/liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-liquidity-mining"
-version = "1.0.1"
+version = "1.0.2"
 description = "Liquidity mining"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/liquidity-mining/src/lib.rs
+++ b/liquidity-mining/src/lib.rs
@@ -838,19 +838,24 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
     /// - `amm_pool_id`: identifier of the AMM pool.
     /// - `shares_amount`: amount of LP shares user want to deposit.
     /// - `amm_pool_id`: identifier of the AMM pool.
-    /// - `get_balance_in_amm`: callback function returning balance of incentivized asset in amm
-    /// pool
+    /// - `get_token_value_of_lp_shares`: callback function returning amount of
+    /// `incentivized_asset` behind `lp_shares`.
     #[require_transactional]
     fn deposit_lp_shares(
         global_farm_id: GlobalFarmId,
         yield_farm_id: YieldFarmId,
         amm_pool_id: T::AmmPoolId,
         shares_amount: Balance,
-        get_balance_in_amm: fn(T::AssetId, T::AmmPoolId) -> Result<Balance, DispatchError>,
+        get_token_value_of_lp_shares: fn(T::AssetId, T::AmmPoolId) -> Result<Balance, DispatchError>,
     ) -> Result<DepositId, DispatchError> {
         let mut deposit = DepositData::new(shares_amount, amm_pool_id);
 
-        Self::do_deposit_lp_shares(&mut deposit, global_farm_id, yield_farm_id, get_balance_in_amm)?;
+        Self::do_deposit_lp_shares(
+            &mut deposit,
+            global_farm_id,
+            yield_farm_id,
+            get_token_value_of_lp_shares,
+        )?;
 
         //Save deposit to storage.
         let deposit_id = Self::get_next_deposit_id()?;
@@ -870,18 +875,18 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
     /// - `global_farm_id`: global farm identifier.
     /// - `yield_farm_id`: yield farm identifier redepositing to.
     /// - `deposit_id`: identifier of the AMM pool.
-    /// - `get_balance_in_amm`: callback function returning balance of incentivized asset in amm
-    /// pool
+    /// - `get_token_value_of_lp_shares`: callback function returning amount of
+    /// `incentivized_asset` behind `lp_shares`.
     fn redeposit_lp_shares(
         global_farm_id: GlobalFarmId,
         yield_farm_id: YieldFarmId,
         deposit_id: DepositId,
-        get_balance_in_amm: fn(T::AssetId, T::AmmPoolId) -> Result<Balance, DispatchError>,
+        get_token_value_of_lp_shares: fn(T::AssetId, T::AmmPoolId) -> Result<Balance, DispatchError>,
     ) -> Result<Balance, DispatchError> {
         <Deposit<T, I>>::try_mutate(deposit_id, |maybe_deposit| {
             let deposit = maybe_deposit.as_mut().ok_or(Error::<T, I>::DepositNotFound)?;
 
-            Self::do_deposit_lp_shares(deposit, global_farm_id, yield_farm_id, get_balance_in_amm)?;
+            Self::do_deposit_lp_shares(deposit, global_farm_id, yield_farm_id, get_token_value_of_lp_shares)?;
 
             Ok(deposit.shares)
         })
@@ -1105,7 +1110,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         deposit: &mut DepositData<T, I>,
         global_farm_id: GlobalFarmId,
         yield_farm_id: YieldFarmId,
-        get_balance_in_amm: fn(T::AssetId, T::AmmPoolId) -> Result<Balance, DispatchError>,
+        get_token_value_of_lp_shares: fn(T::AssetId, T::AmmPoolId) -> Result<Balance, DispatchError>,
     ) -> Result<(), DispatchError> {
         //LP shares can be locked only once in the same yield farm.
         ensure!(
@@ -1136,12 +1141,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
                     Self::maybe_update_farms(global_farm, yield_farm, current_period)?;
 
-                    let valued_shares = Self::get_valued_shares(
-                        deposit.shares,
-                        deposit.amm_pool_id.clone(),
-                        global_farm.incentivized_asset,
-                        get_balance_in_amm,
-                    )?;
+                    let valued_shares =
+                        get_token_value_of_lp_shares(global_farm.incentivized_asset, deposit.amm_pool_id.clone())?;
 
                     let deposit_stake_in_global_farm =
                         math::calculate_global_farm_shares(valued_shares, yield_farm.multiplier)
@@ -1440,20 +1441,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         Ok(())
     }
 
-    /// This function calculate account's valued shares[`Balance`] or error.
-    fn get_valued_shares(
-        shares: Balance,
-        amm: T::AmmPoolId,
-        incentivized_asset: T::AssetId,
-        get_balance_in_amm: fn(T::AssetId, T::AmmPoolId) -> Result<Balance, DispatchError>,
-    ) -> Result<Balance, DispatchError> {
-        let incentivized_asset_balance = get_balance_in_amm(incentivized_asset, amm)?;
-
-        shares
-            .checked_mul(incentivized_asset_balance)
-            .ok_or_else(|| ArithmeticError::Overflow.into())
-    }
-
     /// This function update both (global and yield) farms if conditions are met.
     #[require_transactional]
     fn maybe_update_farms(
@@ -1648,14 +1635,14 @@ impl<T: Config<I>, I: 'static> hydradx_traits::liquidity_mining::Mutate<T::Accou
         yield_farm_id: YieldFarmId,
         amm_pool_id: Self::AmmPoolId,
         shares_amount: Self::Balance,
-        get_balance_in_amm: fn(T::AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
+        get_token_value_of_lp_shares: fn(T::AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
     ) -> Result<DepositId, Self::Error> {
         Self::deposit_lp_shares(
             global_farm_id,
             yield_farm_id,
             amm_pool_id,
             shares_amount,
-            get_balance_in_amm,
+            get_token_value_of_lp_shares,
         )
     }
 
@@ -1663,9 +1650,9 @@ impl<T: Config<I>, I: 'static> hydradx_traits::liquidity_mining::Mutate<T::Accou
         global_farm_id: GlobalFarmId,
         yield_farm_id: YieldFarmId,
         deposit_id: DepositId,
-        get_balance_in_amm: fn(T::AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
+        get_token_value_of_lp_shares: fn(T::AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
     ) -> Result<Self::Balance, Self::Error> {
-        Self::redeposit_lp_shares(global_farm_id, yield_farm_id, deposit_id, get_balance_in_amm)
+        Self::redeposit_lp_shares(global_farm_id, yield_farm_id, deposit_id, get_token_value_of_lp_shares)
     }
 
     fn claim_rewards(

--- a/liquidity-mining/src/tests/claim_rewards.rs
+++ b/liquidity-mining/src/tests/claim_rewards.rs
@@ -283,7 +283,7 @@ fn claim_rewards_should_work() {
                 CHARLIE_ACA_KSM_YIELD_FARM_ID,
                 ACA_KSM_AMM,
                 deposited_amount,
-                |_, _| { Ok(50_u128) }
+                |_, _| { Ok(2_500_u128) }
             ));
 
             pretty_assertions::assert_eq!(
@@ -333,7 +333,7 @@ fn claim_rewards_deposit_with_multiple_entries_should_work() {
                 EVE_FARM,
                 EVE_BSX_TKN1_YIELD_FARM_ID,
                 PREDEFINED_DEPOSIT_IDS[0],
-                |_, _| { Ok(80_u128) }
+                |_, _| { Ok(4_000_u128) }
             ));
 
             set_block_number(800_000);
@@ -341,7 +341,7 @@ fn claim_rewards_deposit_with_multiple_entries_should_work() {
                 DAVE_FARM,
                 DAVE_BSX_TKN1_YIELD_FARM_ID,
                 PREDEFINED_DEPOSIT_IDS[0],
-                |_, _| { Ok(100_u128) }
+                |_, _| { Ok(5_000_u128) }
             ));
 
             let deposit = LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[0]).unwrap();

--- a/liquidity-mining/src/tests/claim_rewards.rs
+++ b/liquidity-mining/src/tests/claim_rewards.rs
@@ -283,7 +283,7 @@ fn claim_rewards_should_work() {
                 CHARLIE_ACA_KSM_YIELD_FARM_ID,
                 ACA_KSM_AMM,
                 deposited_amount,
-                |_, _| { Ok(2_500_u128) }
+                |_, _, _| { Ok(2_500_u128) }
             ));
 
             pretty_assertions::assert_eq!(
@@ -333,7 +333,7 @@ fn claim_rewards_deposit_with_multiple_entries_should_work() {
                 EVE_FARM,
                 EVE_BSX_TKN1_YIELD_FARM_ID,
                 PREDEFINED_DEPOSIT_IDS[0],
-                |_, _| { Ok(4_000_u128) }
+                |_, _, _| { Ok(4_000_u128) }
             ));
 
             set_block_number(800_000);
@@ -341,7 +341,7 @@ fn claim_rewards_deposit_with_multiple_entries_should_work() {
                 DAVE_FARM,
                 DAVE_BSX_TKN1_YIELD_FARM_ID,
                 PREDEFINED_DEPOSIT_IDS[0],
-                |_, _| { Ok(5_000_u128) }
+                |_, _, _| { Ok(5_000_u128) }
             ));
 
             let deposit = LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[0]).unwrap();
@@ -791,7 +791,7 @@ fn deposits_should_claim_same_amount_when_created_in_the_same_period() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 100 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _, _| { Ok(1_u128) }
             ));
 
             set_block_number(1_500);
@@ -812,7 +812,7 @@ fn deposits_should_claim_same_amount_when_created_in_the_same_period() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 100 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _, _| { Ok(1_u128) }
             ));
 
             //charlie
@@ -821,7 +821,7 @@ fn deposits_should_claim_same_amount_when_created_in_the_same_period() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 100 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _, _| { Ok(1_u128) }
             ));
 
             let bob_bsx_balance_0 = Tokens::free_balance(BSX, &BOB);

--- a/liquidity-mining/src/tests/create_yield_farm.rs
+++ b/liquidity-mining/src/tests/create_yield_farm.rs
@@ -416,7 +416,7 @@ fn add_yield_farm_global_farm_full_should_not_work() {
                 GC_BSX_TKN1_YIELD_FARM_ID,
                 BSX_TKN1_AMM,
                 1_000,
-                |_, _| { Ok(10_u128) }
+                |_, _, _| { Ok(10_u128) }
             ));
 
             //stop and destroy

--- a/liquidity-mining/src/tests/deposit_lp_shares.rs
+++ b/liquidity-mining/src/tests/deposit_lp_shares.rs
@@ -39,7 +39,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN1_AMM,
                     deposited_amount,
-                    |_, _| { Ok(2_500_u128) }
+                    |_, _, _| { Ok(2_500_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[0]
@@ -91,7 +91,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN1_AMM,
                     deposited_amount,
-                    |_, _| { Ok(4_160_u128) }
+                    |_, _, _| { Ok(4_160_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[1]
@@ -153,7 +153,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN2_AMM,
                     deposited_amount,
-                    |_, _| { Ok(200_u128) }
+                    |_, _, _| { Ok(200_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[2]
@@ -219,7 +219,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN2_AMM,
                     deposited_amount,
-                    |_, _| { Ok(46_400_u128) }
+                    |_, _, _| { Ok(46_400_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[3]
@@ -288,7 +288,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN2_AMM,
                     deposited_amount,
-                    |_, _| { Ok(261_u128) }
+                    |_, _, _| { Ok(261_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[4]
@@ -356,7 +356,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN2_AMM,
                     deposited_amount,
-                    |_, _| { Ok(768_u128) }
+                    |_, _, _| { Ok(768_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[5]
@@ -423,7 +423,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN1_AMM,
                     deposited_amount,
-                    |_, _| { Ok(38_880_u128) }
+                    |_, _, _| { Ok(38_880_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[6]
@@ -502,7 +502,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     ACA_KSM_AMM,
                     deposited_amount,
-                    |_, _| { Ok(16_000_000_u128) }
+                    |_, _, _| { Ok(16_000_000_u128) }
                 )
                 .unwrap(),
                 deposit_id
@@ -538,17 +538,17 @@ fn deposit_lp_shares_bellow_min_deposit_should_not_work() {
             let yield_farm_id = GC_BSX_TKN1_YIELD_FARM_ID;
 
             assert_noop!(
-                LiquidityMining::deposit_lp_shares(GC_FARM, yield_farm_id, BSX_TKN1_AMM, 0, |_, _| { Ok(10_u128) }),
+                LiquidityMining::deposit_lp_shares(GC_FARM, yield_farm_id, BSX_TKN1_AMM, 0, |_, _, _| { Ok(10_u128) }),
                 Error::<Test, Instance1>::InvalidDepositAmount
             );
 
             assert_noop!(
-                LiquidityMining::deposit_lp_shares(GC_FARM, yield_farm_id, BSX_TKN1_AMM, 1, |_, _| { Ok(10_u128) }),
+                LiquidityMining::deposit_lp_shares(GC_FARM, yield_farm_id, BSX_TKN1_AMM, 1, |_, _, _| { Ok(10_u128) }),
                 Error::<Test, Instance1>::InvalidDepositAmount
             );
 
             assert_noop!(
-                LiquidityMining::deposit_lp_shares(GC_FARM, yield_farm_id, BSX_TKN1_AMM, 8, |_, _| { Ok(10_u128) }),
+                LiquidityMining::deposit_lp_shares(GC_FARM, yield_farm_id, BSX_TKN1_AMM, 8, |_, _, _| { Ok(10_u128) }),
                 Error::<Test, Instance1>::InvalidDepositAmount
             );
 
@@ -558,7 +558,7 @@ fn deposit_lp_shares_bellow_min_deposit_should_not_work() {
                 yield_farm_id,
                 BSX_TKN1_AMM,
                 10,
-                |_, _| { Ok(10_u128) }
+                |_, _, _| { Ok(10_u128) }
             ));
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))
@@ -571,7 +571,7 @@ fn deposit_lp_shares_non_existing_yield_farm_should_not_work() {
     predefined_test_ext_with_deposits().execute_with(|| {
         let _ = with_transaction(|| {
             assert_noop!(
-                LiquidityMining::deposit_lp_shares(GC_FARM, BSX_DOT_YIELD_FARM_ID, BSX_DOT_AMM, 10_000, |_, _| {
+                LiquidityMining::deposit_lp_shares(GC_FARM, BSX_DOT_YIELD_FARM_ID, BSX_DOT_AMM, 10_000, |_, _, _| {
                     Ok(10_u128)
                 }),
                 Error::<Test, Instance1>::YieldFarmNotFound
@@ -589,9 +589,13 @@ fn deposit_lp_shares_stop_yield_farm_should_not_work() {
             assert_ok!(LiquidityMining::stop_yield_farm(GC, GC_FARM, BSX_TKN1_AMM));
 
             assert_noop!(
-                LiquidityMining::deposit_lp_shares(GC_FARM, GC_BSX_TKN1_YIELD_FARM_ID, BSX_TKN1_AMM, 10_000, |_, _| {
-                    Ok(10_u128)
-                }),
+                LiquidityMining::deposit_lp_shares(
+                    GC_FARM,
+                    GC_BSX_TKN1_YIELD_FARM_ID,
+                    BSX_TKN1_AMM,
+                    10_000,
+                    |_, _, _| { Ok(10_u128) }
+                ),
                 Error::<Test, Instance1>::LiquidityMiningCanceled
             );
 

--- a/liquidity-mining/src/tests/deposit_lp_shares.rs
+++ b/liquidity-mining/src/tests/deposit_lp_shares.rs
@@ -39,7 +39,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN1_AMM,
                     deposited_amount,
-                    |_, _| { Ok(50_u128) }
+                    |_, _| { Ok(2_500_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[0]
@@ -91,7 +91,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN1_AMM,
                     deposited_amount,
-                    |_, _| { Ok(52_u128) }
+                    |_, _| { Ok(4_160_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[1]
@@ -153,7 +153,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN2_AMM,
                     deposited_amount,
-                    |_, _| { Ok(8_u128) }
+                    |_, _| { Ok(200_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[2]
@@ -219,7 +219,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN2_AMM,
                     deposited_amount,
-                    |_, _| { Ok(58_u128) }
+                    |_, _| { Ok(46_400_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[3]
@@ -288,7 +288,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN2_AMM,
                     deposited_amount,
-                    |_, _| { Ok(3_u128) }
+                    |_, _| { Ok(261_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[4]
@@ -356,7 +356,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN2_AMM,
                     deposited_amount,
-                    |_, _| { Ok(16_u128) }
+                    |_, _| { Ok(768_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[5]
@@ -423,7 +423,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     BSX_TKN1_AMM,
                     deposited_amount,
-                    |_, _| { Ok(80_u128) }
+                    |_, _| { Ok(38_880_u128) }
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[6]
@@ -502,7 +502,7 @@ fn deposit_lp_shares_should_work() {
                     yield_farm_id,
                     ACA_KSM_AMM,
                     deposited_amount,
-                    |_, _| { Ok(16_u128) }
+                    |_, _| { Ok(16_000_000_u128) }
                 )
                 .unwrap(),
                 deposit_id

--- a/liquidity-mining/src/tests/destroy_global_farm.rs
+++ b/liquidity-mining/src/tests/destroy_global_farm.rs
@@ -68,7 +68,7 @@ fn destroy_global_farm_should_work() {
                 yield_farm_id,
                 ACA_KSM_AMM,
                 1_000,
-                |_, _| { Ok(10_u128) },
+                |_, _, _| { Ok(10_u128) },
             ));
 
             //Stop farming.

--- a/liquidity-mining/src/tests/full_run.rs
+++ b/liquidity-mining/src/tests/full_run.rs
@@ -76,7 +76,7 @@ fn non_full_farm_running_longer_than_expected() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(5_000 * ONE) }
             ));
 
             set_block_number(140);
@@ -86,7 +86,7 @@ fn non_full_farm_running_longer_than_expected() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 2_500 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(2_500 * ONE) }
             ));
 
             //charlie
@@ -95,7 +95,7 @@ fn non_full_farm_running_longer_than_expected() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 2_500 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(2_500 * ONE) }
             ));
 
             set_block_number(401);
@@ -213,7 +213,7 @@ fn non_full_farm_distribute_everything_and_update_farms() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(5_000 * ONE) }
             ));
 
             set_block_number(140);
@@ -223,7 +223,7 @@ fn non_full_farm_distribute_everything_and_update_farms() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 2_500 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(2_500 * ONE) }
             ));
 
             //charlie
@@ -232,7 +232,7 @@ fn non_full_farm_distribute_everything_and_update_farms() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 2_500 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(2_500 * ONE) }
             ));
 
             set_block_number(401);
@@ -339,7 +339,7 @@ fn overcrowded_farm_running_longer_than_expected() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 10_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(10_000 * ONE) }
             ));
 
             //bob
@@ -348,7 +348,7 @@ fn overcrowded_farm_running_longer_than_expected() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(5_000 * ONE) }
             ));
 
             //charlie
@@ -357,7 +357,7 @@ fn overcrowded_farm_running_longer_than_expected() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(5_000 * ONE) }
             ));
 
             let mut block_number = 131;
@@ -508,7 +508,7 @@ fn full_farm_running_planned_time() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(5_000 * ONE) }
             ));
 
             //bob
@@ -517,7 +517,7 @@ fn full_farm_running_planned_time() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(5_000 * ONE) }
             ));
 
             //charlie
@@ -526,7 +526,7 @@ fn full_farm_running_planned_time() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(5_000 * ONE) }
             ));
 
             let alice_bsx_balance_0 = Tokens::free_balance(BSX, &ALICE);
@@ -677,7 +677,7 @@ fn yield_farm_should_claim_expected_amount() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 10_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(10_000 * ONE) }
             ));
 
             set_block_number(1_500);
@@ -698,7 +698,7 @@ fn yield_farm_should_claim_expected_amount() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 10_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(10_000 * ONE) }
             ));
 
             set_block_number(2_500);
@@ -708,7 +708,7 @@ fn yield_farm_should_claim_expected_amount() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 10_000 * ONE,
-                |_, _| { Ok(1_u128) }
+                |_, _| { Ok(10_000 * ONE) }
             ));
 
             let pot = LiquidityMining2::pot_account_id().unwrap();

--- a/liquidity-mining/src/tests/full_run.rs
+++ b/liquidity-mining/src/tests/full_run.rs
@@ -76,7 +76,7 @@ fn non_full_farm_running_longer_than_expected() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(5_000 * ONE) }
+                |_, _, _| { Ok(5_000 * ONE) }
             ));
 
             set_block_number(140);
@@ -86,7 +86,7 @@ fn non_full_farm_running_longer_than_expected() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 2_500 * ONE,
-                |_, _| { Ok(2_500 * ONE) }
+                |_, _, _| { Ok(2_500 * ONE) }
             ));
 
             //charlie
@@ -95,7 +95,7 @@ fn non_full_farm_running_longer_than_expected() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 2_500 * ONE,
-                |_, _| { Ok(2_500 * ONE) }
+                |_, _, _| { Ok(2_500 * ONE) }
             ));
 
             set_block_number(401);
@@ -213,7 +213,7 @@ fn non_full_farm_distribute_everything_and_update_farms() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(5_000 * ONE) }
+                |_, _, _| { Ok(5_000 * ONE) }
             ));
 
             set_block_number(140);
@@ -223,7 +223,7 @@ fn non_full_farm_distribute_everything_and_update_farms() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 2_500 * ONE,
-                |_, _| { Ok(2_500 * ONE) }
+                |_, _, _| { Ok(2_500 * ONE) }
             ));
 
             //charlie
@@ -232,7 +232,7 @@ fn non_full_farm_distribute_everything_and_update_farms() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 2_500 * ONE,
-                |_, _| { Ok(2_500 * ONE) }
+                |_, _, _| { Ok(2_500 * ONE) }
             ));
 
             set_block_number(401);
@@ -339,7 +339,7 @@ fn overcrowded_farm_running_longer_than_expected() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 10_000 * ONE,
-                |_, _| { Ok(10_000 * ONE) }
+                |_, _, _| { Ok(10_000 * ONE) }
             ));
 
             //bob
@@ -348,7 +348,7 @@ fn overcrowded_farm_running_longer_than_expected() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(5_000 * ONE) }
+                |_, _, _| { Ok(5_000 * ONE) }
             ));
 
             //charlie
@@ -357,7 +357,7 @@ fn overcrowded_farm_running_longer_than_expected() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(5_000 * ONE) }
+                |_, _, _| { Ok(5_000 * ONE) }
             ));
 
             let mut block_number = 131;
@@ -508,7 +508,7 @@ fn full_farm_running_planned_time() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(5_000 * ONE) }
+                |_, _, _| { Ok(5_000 * ONE) }
             ));
 
             //bob
@@ -517,7 +517,7 @@ fn full_farm_running_planned_time() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(5_000 * ONE) }
+                |_, _, _| { Ok(5_000 * ONE) }
             ));
 
             //charlie
@@ -526,7 +526,7 @@ fn full_farm_running_planned_time() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 5_000 * ONE,
-                |_, _| { Ok(5_000 * ONE) }
+                |_, _, _| { Ok(5_000 * ONE) }
             ));
 
             let alice_bsx_balance_0 = Tokens::free_balance(BSX, &ALICE);
@@ -677,7 +677,7 @@ fn yield_farm_should_claim_expected_amount() {
                 YIELD_FARM_A,
                 BSX_TKN1_AMM,
                 10_000 * ONE,
-                |_, _| { Ok(10_000 * ONE) }
+                |_, _, _| { Ok(10_000 * ONE) }
             ));
 
             set_block_number(1_500);
@@ -698,7 +698,7 @@ fn yield_farm_should_claim_expected_amount() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 10_000 * ONE,
-                |_, _| { Ok(10_000 * ONE) }
+                |_, _, _| { Ok(10_000 * ONE) }
             ));
 
             set_block_number(2_500);
@@ -708,7 +708,7 @@ fn yield_farm_should_claim_expected_amount() {
                 YIELD_FARM_B,
                 BSX_TKN2_AMM,
                 10_000 * ONE,
-                |_, _| { Ok(10_000 * ONE) }
+                |_, _, _| { Ok(10_000 * ONE) }
             ));
 
             let pot = LiquidityMining2::pot_account_id().unwrap();

--- a/liquidity-mining/src/tests/mock.rs
+++ b/liquidity-mining/src/tests/mock.rs
@@ -269,14 +269,6 @@ impl AMM<AccountId, AssetId, AssetPair, Balance> for Amm {
             None => BSX,
         })
     }
-
-    fn get_liquidity_behind_shares(
-        _asset_a: AssetId,
-        _asset_b: AssetId,
-        _shares_amount: Balance,
-    ) -> Result<(u128, u128), frame_support::dispatch::DispatchError> {
-        Err(sp_runtime::DispatchError::Other("NotImplemented"))
-    }
 }
 
 pub fn asset_pair_to_map_key(assets: AssetPair) -> String {

--- a/liquidity-mining/src/tests/mock.rs
+++ b/liquidity-mining/src/tests/mock.rs
@@ -269,6 +269,14 @@ impl AMM<AccountId, AssetId, AssetPair, Balance> for Amm {
             None => BSX,
         })
     }
+
+    fn get_liquidity_behind_shares(
+        _asset_a: AssetId,
+        _asset_b: AssetId,
+        _shares_amount: Balance,
+    ) -> Result<(u128, u128), frame_support::dispatch::DispatchError> {
+        Err(sp_runtime::DispatchError::Other("NotImplemented"))
+    }
 }
 
 pub fn asset_pair_to_map_key(assets: AssetPair) -> String {

--- a/liquidity-mining/src/tests/redeposit_lp_shares.rs
+++ b/liquidity-mining/src/tests/redeposit_lp_shares.rs
@@ -29,7 +29,7 @@ fn redeposit_lp_shares_should_work() {
                     EVE_FARM,
                     EVE_BSX_TKN1_YIELD_FARM_ID,
                     PREDEFINED_DEPOSIT_IDS[0],
-                    |_, _| { Ok(500_u128) }
+                    |_, _, _| { Ok(500_u128) }
                 )
                 .unwrap(),
                 50
@@ -49,7 +49,7 @@ fn redeposit_lp_shares_should_work() {
                     DAVE_FARM,
                     DAVE_BSX_TKN1_YIELD_FARM_ID,
                     PREDEFINED_DEPOSIT_IDS[0],
-                    |_, _| { Ok(5_000_u128) }
+                    |_, _, _| { Ok(5_000_u128) }
                 )
                 .unwrap(),
                 50
@@ -112,7 +112,7 @@ fn redeposit_lp_shares_deposit_not_found_should_not_work() {
             let yield_farm_id = DAVE_BSX_TKN1_YIELD_FARM_ID;
 
             assert_noop!(
-                LiquidityMining::redeposit_lp_shares(DAVE_FARM, yield_farm_id, 999_999_999, |_, _| { Ok(10_u128) }),
+                LiquidityMining::redeposit_lp_shares(DAVE_FARM, yield_farm_id, 999_999_999, |_, _, _| { Ok(10_u128) }),
                 Error::<Test, Instance1>::DepositNotFound
             );
 
@@ -129,7 +129,7 @@ fn redeposit_lp_shares_to_wrong_yield_farm_should_not_work() {
             let yield_farm_id = EVE_BSX_TKN2_YIELD_FARM_ID; //original deposit is for bsx/tkn1 assert pair
 
             assert_noop!(
-                LiquidityMining::redeposit_lp_shares(EVE_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _| {
+                LiquidityMining::redeposit_lp_shares(EVE_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _, _| {
                     Ok(10_u128)
                 }),
                 Error::<Test, Instance1>::YieldFarmNotFound
@@ -138,7 +138,7 @@ fn redeposit_lp_shares_to_wrong_yield_farm_should_not_work() {
             // Same global farm different asset pair.
             let yield_farm_id = GC_BSX_TKN2_YIELD_FARM_ID;
             assert_noop!(
-                LiquidityMining::redeposit_lp_shares(GC_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _| {
+                LiquidityMining::redeposit_lp_shares(GC_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _, _| {
                     Ok(10_u128)
                 }),
                 Error::<Test, Instance1>::YieldFarmNotFound
@@ -147,7 +147,7 @@ fn redeposit_lp_shares_to_wrong_yield_farm_should_not_work() {
             //Desired yield farm is not in the provided global farm.
             let yield_farm_id = EVE_BSX_TKN1_YIELD_FARM_ID;
             assert_noop!(
-                LiquidityMining::redeposit_lp_shares(GC_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _| {
+                LiquidityMining::redeposit_lp_shares(GC_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _, _| {
                     Ok(10_u128)
                 }),
                 Error::<Test, Instance1>::YieldFarmNotFound
@@ -170,7 +170,7 @@ fn redeposit_lp_shares_to_not_active_yield_farm_should_not_work() {
                 yield_farm_id,
                 BSX_TKN1_AMM,
                 1_000,
-                |_, _| { Ok(10_u128) }
+                |_, _, _| { Ok(10_u128) }
             ));
 
             // Redeposit to stopped farm.
@@ -182,7 +182,7 @@ fn redeposit_lp_shares_to_not_active_yield_farm_should_not_work() {
                 .is_stopped());
 
             assert_noop!(
-                LiquidityMining::redeposit_lp_shares(EVE_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _| {
+                LiquidityMining::redeposit_lp_shares(EVE_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _, _| {
                     Ok(10_u128)
                 }),
                 Error::<Test, Instance1>::LiquidityMiningCanceled
@@ -202,7 +202,7 @@ fn redeposit_lp_shares_to_not_active_yield_farm_should_not_work() {
                 .is_deleted());
 
             assert_noop!(
-                LiquidityMining::redeposit_lp_shares(EVE_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _| {
+                LiquidityMining::redeposit_lp_shares(EVE_FARM, yield_farm_id, PREDEFINED_DEPOSIT_IDS[0], |_, _, _| {
                     Ok(10_u128)
                 }),
                 Error::<Test, Instance1>::LiquidityMiningCanceled
@@ -224,7 +224,7 @@ fn redeposit_lp_shares_non_existing_farm_should_not_work() {
                     EVE_FARM,
                     NON_EXISTING_YILED_FARM_ID,
                     PREDEFINED_DEPOSIT_IDS[0],
-                    |_, _| { Ok(10_u128) }
+                    |_, _, _| { Ok(10_u128) }
                 ),
                 Error::<Test, Instance1>::YieldFarmNotFound
             );
@@ -235,7 +235,7 @@ fn redeposit_lp_shares_non_existing_farm_should_not_work() {
                     NON_EXISTING_GLOBAL_FARM_ID,
                     GC_BSX_TKN2_YIELD_FARM_ID,
                     PREDEFINED_DEPOSIT_IDS[0],
-                    |_, _| { Ok(10_u128) }
+                    |_, _, _| { Ok(10_u128) }
                 ),
                 Error::<Test, Instance1>::YieldFarmNotFound //NOTE: check for yield farm existence is first that's why this error.
             );
@@ -254,7 +254,7 @@ fn redeposit_lp_shares_same_deposit_should_not_work() {
                     GC_FARM,
                     GC_BSX_TKN1_YIELD_FARM_ID,
                     PREDEFINED_DEPOSIT_IDS[0],
-                    |_, _| { Ok(10_u128) }
+                    |_, _, _| { Ok(10_u128) }
                 ),
                 Error::<Test, Instance1>::DoubleLock
             );

--- a/liquidity-mining/src/tests/redeposit_lp_shares.rs
+++ b/liquidity-mining/src/tests/redeposit_lp_shares.rs
@@ -29,7 +29,7 @@ fn redeposit_lp_shares_should_work() {
                     EVE_FARM,
                     EVE_BSX_TKN1_YIELD_FARM_ID,
                     PREDEFINED_DEPOSIT_IDS[0],
-                    |_, _| { Ok(10_u128) }
+                    |_, _| { Ok(500_u128) }
                 )
                 .unwrap(),
                 50
@@ -49,7 +49,7 @@ fn redeposit_lp_shares_should_work() {
                     DAVE_FARM,
                     DAVE_BSX_TKN1_YIELD_FARM_ID,
                     PREDEFINED_DEPOSIT_IDS[0],
-                    |_, _| { Ok(100_u128) }
+                    |_, _| { Ok(5_000_u128) }
                 )
                 .unwrap(),
                 50

--- a/liquidity-mining/src/tests/test_ext.rs
+++ b/liquidity-mining/src/tests/test_ext.rs
@@ -245,7 +245,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN1_YIELD_FARM_ID,
                 BSX_TKN1_AMM,
                 deposited_amount,
-                |_, _| { Ok(50_u128) },
+                |_, _| { Ok(2_500_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[0]).is_some());
@@ -258,7 +258,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                     GC_BSX_TKN1_YIELD_FARM_ID,
                     BSX_TKN1_AMM,
                     deposited_amount,
-                    |_, _| { Ok(52_u128) },
+                    |_, _| { Ok(4_160_u128) },
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[1]
@@ -273,7 +273,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN2_YIELD_FARM_ID,
                 BSX_TKN2_AMM,
                 deposited_amount,
-                |_, _| { Ok(8_u128) },
+                |_, _| { Ok(200_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[2]).is_some());
@@ -287,7 +287,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN2_YIELD_FARM_ID,
                 BSX_TKN2_AMM,
                 deposited_amount,
-                |_, _| { Ok(58_u128) },
+                |_, _| { Ok(46_400_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[3]).is_some());
@@ -301,7 +301,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN2_YIELD_FARM_ID,
                 BSX_TKN2_AMM,
                 deposited_amount,
-                |_, _| { Ok(3_u128) },
+                |_, _| { Ok(261_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[4]).is_some());
@@ -315,7 +315,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN2_YIELD_FARM_ID,
                 BSX_TKN2_AMM,
                 deposited_amount,
-                |_, _| { Ok(16_u128) },
+                |_, _| { Ok(768_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[5]).is_some());
@@ -329,7 +329,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN1_YIELD_FARM_ID,
                 BSX_TKN1_AMM,
                 deposited_amount,
-                |_, _| { Ok(80_u128) },
+                |_, _| { Ok(38_880_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[6]).is_some());

--- a/liquidity-mining/src/tests/test_ext.rs
+++ b/liquidity-mining/src/tests/test_ext.rs
@@ -245,7 +245,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN1_YIELD_FARM_ID,
                 BSX_TKN1_AMM,
                 deposited_amount,
-                |_, _| { Ok(2_500_u128) },
+                |_, _, _| { Ok(2_500_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[0]).is_some());
@@ -258,7 +258,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                     GC_BSX_TKN1_YIELD_FARM_ID,
                     BSX_TKN1_AMM,
                     deposited_amount,
-                    |_, _| { Ok(4_160_u128) },
+                    |_, _, _| { Ok(4_160_u128) },
                 )
                 .unwrap(),
                 PREDEFINED_DEPOSIT_IDS[1]
@@ -273,7 +273,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN2_YIELD_FARM_ID,
                 BSX_TKN2_AMM,
                 deposited_amount,
-                |_, _| { Ok(200_u128) },
+                |_, _, _| { Ok(200_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[2]).is_some());
@@ -287,7 +287,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN2_YIELD_FARM_ID,
                 BSX_TKN2_AMM,
                 deposited_amount,
-                |_, _| { Ok(46_400_u128) },
+                |_, _, _| { Ok(46_400_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[3]).is_some());
@@ -301,7 +301,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN2_YIELD_FARM_ID,
                 BSX_TKN2_AMM,
                 deposited_amount,
-                |_, _| { Ok(261_u128) },
+                |_, _, _| { Ok(261_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[4]).is_some());
@@ -315,7 +315,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN2_YIELD_FARM_ID,
                 BSX_TKN2_AMM,
                 deposited_amount,
-                |_, _| { Ok(768_u128) },
+                |_, _, _| { Ok(768_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[5]).is_some());
@@ -329,7 +329,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 GC_BSX_TKN1_YIELD_FARM_ID,
                 BSX_TKN1_AMM,
                 deposited_amount,
-                |_, _| { Ok(38_880_u128) },
+                |_, _, _| { Ok(38_880_u128) },
             ));
 
             assert!(LiquidityMining::deposit(PREDEFINED_DEPOSIT_IDS[6]).is_some());

--- a/liquidity-mining/src/tests/tests.rs
+++ b/liquidity-mining/src/tests/tests.rs
@@ -2173,7 +2173,7 @@ fn get_global_farm_id_should_work() {
                 EVE_FARM,
                 EVE_BSX_TKN1_YIELD_FARM_ID,
                 PREDEFINED_DEPOSIT_IDS[0],
-                |_, _| { Ok(10_u128) }
+                |_, _, _| { Ok(10_u128) }
             ));
 
             pretty_assertions::assert_eq!(

--- a/liquidity-mining/src/tests/withdraw_lp_shares.rs
+++ b/liquidity-mining/src/tests/withdraw_lp_shares.rs
@@ -498,7 +498,7 @@ fn withdraw_shares_should_work() {
                 CHARLIE_ACA_KSM_YIELD_FARM_ID,
                 ACA_KSM_AMM,
                 deposited_amount,
-                |_, _| { Ok(2_500_u128) }
+                |_, _, _| { Ok(2_500_u128) }
             ));
 
             const DEPOSIT_ID: DepositId = 1;
@@ -547,14 +547,14 @@ fn withdraw_with_multiple_entries_and_flush_should_work() {
                 DAVE_FARM,
                 DAVE_BSX_TKN1_YIELD_FARM_ID,
                 PREDEFINED_DEPOSIT_IDS[0],
-                |_, _| { Ok(10_u128) },
+                |_, _, _| { Ok(10_u128) },
             ));
 
             assert_ok!(LiquidityMining::redeposit_lp_shares(
                 EVE_FARM,
                 EVE_BSX_TKN1_YIELD_FARM_ID,
                 PREDEFINED_DEPOSIT_IDS[0],
-                |_, _| { Ok(10_u128) },
+                |_, _, _| { Ok(10_u128) },
             ));
             //NOTE: predefined_deposit_ids[0] is deposited in 3 yield farms now.
 

--- a/liquidity-mining/src/tests/withdraw_lp_shares.rs
+++ b/liquidity-mining/src/tests/withdraw_lp_shares.rs
@@ -498,7 +498,7 @@ fn withdraw_shares_should_work() {
                 CHARLIE_ACA_KSM_YIELD_FARM_ID,
                 ACA_KSM_AMM,
                 deposited_amount,
-                |_, _| { Ok(50_u128) }
+                |_, _| { Ok(2_500_u128) }
             ));
 
             const DEPOSIT_ID: DepositId = 1;

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-traits"
-version = "0.8.4"
+version = "0.9.0"
 description = "Shared traits"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -127,6 +127,13 @@ pub trait AMM<AccountId, AssetId, AssetPair, Amount: Zero> {
     fn get_max_out_ratio() -> u128;
 
     fn get_fee(pool_account_id: &AccountId) -> (u32, u32);
+
+    /// This function calculates amount of assets behind the `share_token`s.
+    fn get_liquidity_behind_shares(
+        asset_a: AssetId,
+        asset_b: AssetId,
+        shares_amount: Amount,
+    ) -> Result<(u128, u128), dispatch::DispatchError>;
 }
 
 pub trait Resolver<AccountId, Intention, E> {

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -127,13 +127,6 @@ pub trait AMM<AccountId, AssetId, AssetPair, Amount: Zero> {
     fn get_max_out_ratio() -> u128;
 
     fn get_fee(pool_account_id: &AccountId) -> (u32, u32);
-
-    /// This function calculates amount of assets behind the `share_token`s.
-    fn get_liquidity_behind_shares(
-        asset_a: AssetId,
-        asset_b: AssetId,
-        shares_amount: Amount,
-    ) -> Result<(u128, u128), dispatch::DispatchError>;
 }
 
 pub trait Resolver<AccountId, Intention, E> {
@@ -192,4 +185,16 @@ pub trait LockedBalance<AssetId, AccountId, Balance> {
 /// Should return `None` if no price is available.
 pub trait NativePriceOracle<AssetId, Price> {
     fn price(currency: AssetId) -> Option<Price>;
+}
+
+/// Implementers of this trait provides information about user's position in the AMM pool.
+pub trait AMMPosition<AssetId, Balance> {
+    type Error;
+
+    /// This function calculates amount of assets behind the `share_token`s.
+    fn get_liquidity_behind_shares(
+        asset_a: AssetId,
+        asset_b: AssetId,
+        shares_amount: Balance,
+    ) -> Result<(Balance, Balance), Self::Error>;
 }

--- a/traits/src/liquidity_mining.rs
+++ b/traits/src/liquidity_mining.rs
@@ -102,7 +102,7 @@ pub trait Mutate<AccountId, AssetId, BlockNumber> {
         yield_farm_id: YieldFarmId,
         amm_pool_id: Self::AmmPoolId,
         shares_amount: Self::Balance,
-        get_balance_in_amm: fn(AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
+        get_token_value_of_lp_shares: fn(AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
     ) -> Result<DepositId, Self::Error>;
 
     /// Redeposit already locked LP shares to another yield farm.
@@ -113,7 +113,7 @@ pub trait Mutate<AccountId, AssetId, BlockNumber> {
         global_farm_id: GlobalFarmId,
         yield_farm_id: YieldFarmId,
         deposit_id: DepositId,
-        get_balance_in_amm: fn(AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
+        get_token_value_of_lp_shares: fn(AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
     ) -> Result<Self::Balance, Self::Error>;
 
     /// Claim rewards for given deposit.

--- a/traits/src/liquidity_mining.rs
+++ b/traits/src/liquidity_mining.rs
@@ -102,7 +102,7 @@ pub trait Mutate<AccountId, AssetId, BlockNumber> {
         yield_farm_id: YieldFarmId,
         amm_pool_id: Self::AmmPoolId,
         shares_amount: Self::Balance,
-        get_token_value_of_lp_shares: fn(AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
+        get_token_value_of_lp_shares: fn(AssetId, Self::AmmPoolId, Self::Balance) -> Result<Self::Balance, Self::Error>,
     ) -> Result<DepositId, Self::Error>;
 
     /// Redeposit already locked LP shares to another yield farm.
@@ -113,7 +113,7 @@ pub trait Mutate<AccountId, AssetId, BlockNumber> {
         global_farm_id: GlobalFarmId,
         yield_farm_id: YieldFarmId,
         deposit_id: DepositId,
-        get_token_value_of_lp_shares: fn(AssetId, Self::AmmPoolId) -> Result<Self::Balance, Self::Error>,
+        get_token_value_of_lp_shares: fn(AssetId, Self::AmmPoolId, Self::Balance) -> Result<Self::Balance, Self::Error>,
     ) -> Result<Self::Balance, Self::Error>;
 
     /// Claim rewards for given deposit.


### PR DESCRIPTION
Bug: Equation for `valued_shares` calculation was not correct.
Fix: Fixed by asking the value of LP shares  directly from AMM. 