### PR TITLE
docs(nft): do_transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-nft"
-version = "4.0.1"
+version = "4.0.2"
 description = "A generic NFT pallet for managing non-fungible tokens"
 authors = ["GalacticCoucil"]
 edition = "2021"

--- a/nft/src/lib.rs
+++ b/nft/src/lib.rs
@@ -377,6 +377,10 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
+    /// Transfer NFT from account `from` to `to`.
+    /// Fails if `from` is not the NFT owner.
+    ///
+    /// Is a no-op if `from` is the same as `to`.
     fn do_transfer(
         collection_id: T::NftCollectionId,
         item_id: T::NftItemId,


### PR DESCRIPTION
Fixes #99 
The implementation is consistent with other pallets (e.g. [pallet-balances](https://github.com/paritytech/substrate/blob/a1dee7ecd2a157c490d189f0932b32aa12106857/frame/balances/src/lib.rs#L1486)). 
It's a no-op if `from == to`, meaning that the chain state is not modified so no event needs to be emitted.