### PR TITLE
feat: non dustable LM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquidity-mining"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "fixed",
  "frame-support",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft"
-version = "4.0.2"
+version = "5.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/liquidity-mining/Cargo.toml
+++ b/liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-liquidity-mining"
-version = "1.0.2"
+version = "1.1.0"
 description = "Liquidity mining"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/liquidity-mining/proptest-regressions/tests/invariants.txt
+++ b/liquidity-mining/proptest-regressions/tests/invariants.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 804e6f3099933d7502effb9911c3ea01a7ad7d61c6a94c89cc9e32d7d1986399 # shrinks to (_, mut yield_farm, current_period, yield_farm_rewards, left_to_distribute) = (GlobalFarmData { id: 1, owner: 10, updated_at: 2932391, total_shares_z: 1482358019934, accumulated_rpz: FixedU128(652602029.000000000000000000), reward_currency: 1000, accumulated_rewards: 3548468033427364050036, paid_accumulated_rewards: 1932087676117527289441, yield_per_period: 0.2%, planned_yielding_periods: 1000, blocks_per_period: 1000, incentivized_asset: 1000, max_reward_per_period: 477605826377853174, min_deposit: 1, live_yield_farms_count: 0, total_yield_farms_count: 0, price_adjustment: FixedU128(1.000000000000000000), state: FarmState::Active }, YieldFarmData { id: 2, updated_at: 2932511, total_shares: 0, total_valued_shares: 1482358019934, accumulated_rpvs: FixedU128(281873695.000000000000000000), accumulated_rpz: FixedU128(552928289.000000000000000000), loyalty_curve: None, multiplier: FixedU128(1.000000000000000000), state: FarmState::Active, entries_count: 0, left_to_distribute: 0, _phantom: PhantomData }, 3591832, 417837732391680236131, 417837733391680835634)

--- a/liquidity-mining/src/lib.rs
+++ b/liquidity-mining/src/lib.rs
@@ -140,7 +140,7 @@ pub mod pallet {
         fn integrity_test() {
             assert!(
                 T::MaxFarmEntriesPerDeposit::get().ge(&1_u32),
-                "`T::MaxFarmEntriesPerDeposit` must be greater or eaqual to 1"
+                "`T::MaxFarmEntriesPerDeposit` must be greater or equal to 1"
             );
         }
     }

--- a/liquidity-mining/src/tests/create_global_farm.rs
+++ b/liquidity-mining/src/tests/create_global_farm.rs
@@ -207,7 +207,7 @@ fn create_global_farm_with_inssufficient_balance_should_not_work() {
         let _ = with_transaction(|| {
             assert_noop!(
                 LiquidityMining::create_global_farm(
-                    1_000_001,
+                    1_000_001 * ONE,
                     1_000,
                     1,
                     BSX,
@@ -218,6 +218,54 @@ fn create_global_farm_with_inssufficient_balance_should_not_work() {
                     One::one(),
                 ),
                 Error::<Test, Instance1>::InsufficientRewardCurrencyBalance
+            );
+
+            TransactionOutcome::Commit(DispatchResult::Ok(()))
+        });
+    });
+}
+
+#[test]
+fn create_global_farm_should_not_work_when_reward_currency_is_not_registered() {
+    new_test_ext().execute_with(|| {
+        let _ = with_transaction(|| {
+            assert_noop!(
+                LiquidityMining::create_global_farm(
+                    1_000_000 * ONE,
+                    1_000,
+                    1,
+                    BSX,
+                    UNKNOWN_ASSET,
+                    GC,
+                    Perquintill::from_percent(20),
+                    10,
+                    One::one(),
+                ),
+                Error::<Test, Instance1>::RewardCurrencyNotRegistered
+            );
+
+            TransactionOutcome::Commit(DispatchResult::Ok(()))
+        });
+    });
+}
+
+#[test]
+fn create_global_farm_should_not_work_when_incentivized_asset_is_not_registered() {
+    new_test_ext().execute_with(|| {
+        let _ = with_transaction(|| {
+            assert_noop!(
+                LiquidityMining::create_global_farm(
+                    1_000_000 * ONE,
+                    1_000,
+                    1,
+                    UNKNOWN_ASSET,
+                    BSX,
+                    GC,
+                    Perquintill::from_percent(20),
+                    10,
+                    One::one(),
+                ),
+                Error::<Test, Instance1>::IncentivizedAssetNotRegistered
             );
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))

--- a/liquidity-mining/src/tests/create_global_farm.rs
+++ b/liquidity-mining/src/tests/create_global_farm.rs
@@ -83,6 +83,8 @@ fn create_global_farm_should_work() {
             );
 
             pretty_assertions::assert_eq!(LiquidityMining::global_farm(global_farm_id).unwrap(), global_farm);
+            //Non-dustable check
+            pretty_assertions::assert_eq!(Whitelist::contains(&global_farm_account), true);
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))
         });

--- a/liquidity-mining/src/tests/create_yield_farm.rs
+++ b/liquidity-mining/src/tests/create_yield_farm.rs
@@ -38,6 +38,7 @@ fn create_yield_farm_should_work() {
                 loyalty_curve: Some(LoyaltyCurve::default()),
                 entries_count: 0,
                 state: FarmState::Active,
+                left_to_distribute: 0,
                 _phantom: PhantomData::default(),
             },
             BSX_ACA_AMM,
@@ -66,6 +67,7 @@ fn create_yield_farm_should_work() {
                 loyalty_curve: None,
                 entries_count: 0,
                 state: FarmState::Active,
+                left_to_distribute: 0,
                 _phantom: PhantomData::default(),
             },
             BSX_KSM_AMM,
@@ -97,6 +99,7 @@ fn create_yield_farm_should_work() {
                 }),
                 state: FarmState::Active,
                 entries_count: 0,
+                left_to_distribute: 0,
                 _phantom: PhantomData::default(),
             },
             BSX_ETH_AMM,
@@ -128,6 +131,7 @@ fn create_yield_farm_should_work() {
                 }),
                 state: FarmState::Active,
                 entries_count: 0,
+                left_to_distribute: 0,
                 _phantom: PhantomData::default(),
             },
             BSX_ETH_AMM,
@@ -171,10 +175,6 @@ fn create_yield_farm_should_work() {
                     LiquidityMining::yield_farm((amm_id, global_farm_id, yield_farm.id)).unwrap(),
                     YieldFarmData { ..yield_farm }
                 );
-
-                let yield_farm_account = LiquidityMining::farm_account_id(yield_farm.id).unwrap();
-                //Non-dustable check
-                pretty_assertions::assert_eq!(Whitelist::contains(&yield_farm_account), true);
             }
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))

--- a/liquidity-mining/src/tests/create_yield_farm.rs
+++ b/liquidity-mining/src/tests/create_yield_farm.rs
@@ -171,6 +171,10 @@ fn create_yield_farm_should_work() {
                     LiquidityMining::yield_farm((amm_id, global_farm_id, yield_farm.id)).unwrap(),
                     YieldFarmData { ..yield_farm }
                 );
+
+                let yield_farm_account = LiquidityMining::farm_account_id(yield_farm.id).unwrap();
+                //Non-dustable check
+                pretty_assertions::assert_eq!(Whitelist::contains(&yield_farm_account), true);
             }
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))

--- a/liquidity-mining/src/tests/destroy_global_farm.rs
+++ b/liquidity-mining/src/tests/destroy_global_farm.rs
@@ -104,10 +104,8 @@ fn destroy_global_farm_should_work() {
                 charlie_reward_currency_balance + undistributed_rewards
             );
 
-            //NOTE: farm's account should stay in the non-dustable until farm's is removed from
-            //storage.
-            //Non-dustable check
-            pretty_assertions::assert_eq!(Whitelist::contains(&farm_account), true);
+            //Farm's account should be removed when farm is destroyed.
+            pretty_assertions::assert_eq!(Whitelist::contains(&farm_account), false);
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))
         });

--- a/liquidity-mining/src/tests/destroy_global_farm.rs
+++ b/liquidity-mining/src/tests/destroy_global_farm.rs
@@ -48,6 +48,9 @@ fn destroy_global_farm_should_work() {
                 bob_reward_currency_balance + undistributed_rewards
             );
 
+            //Non-dustable check
+            pretty_assertions::assert_eq!(Whitelist::contains(&farm_account), false);
+
             TransactionOutcome::Commit(DispatchResult::Ok(()))
         });
     });
@@ -100,6 +103,11 @@ fn destroy_global_farm_should_work() {
                 Tokens::free_balance(predefined_global_farm.reward_currency, &CHARLIE),
                 charlie_reward_currency_balance + undistributed_rewards
             );
+
+            //NOTE: farm's account should stay in the non-dustable until farm's is removed from
+            //storage.
+            //Non-dustable check
+            pretty_assertions::assert_eq!(Whitelist::contains(&farm_account), true);
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))
         });

--- a/liquidity-mining/src/tests/destroy_yield_farm.rs
+++ b/liquidity-mining/src/tests/destroy_yield_farm.rs
@@ -63,14 +63,15 @@ fn destroy_yield_farm_with_deposits_should_work() {
             //global-farm's account.
             pretty_assertions::assert_eq!(
                 Tokens::free_balance(BSX, &global_farm_account),
-                global_farm_bsx_balance.checked_add(yield_farm_0.left_to_distribute).unwrap()
+                global_farm_bsx_balance
+                    .checked_add(yield_farm_0.left_to_distribute)
+                    .unwrap()
             );
-            
+
             pretty_assertions::assert_eq!(
                 Tokens::free_balance(BSX, &pot),
                 pot_balance_0.checked_sub(yield_farm_0.left_to_distribute).unwrap()
             );
-
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))
         });

--- a/liquidity-mining/src/tests/full_run.rs
+++ b/liquidity-mining/src/tests/full_run.rs
@@ -719,7 +719,7 @@ fn yield_farm_should_claim_expected_amount() {
                 LiquidityMining2::yield_farm(yield_farm_a_key)
                     .unwrap()
                     .left_to_distribute,
-                0 * ONE
+                0
             );
             pretty_assertions::assert_eq!(
                 LiquidityMining2::yield_farm(yield_farm_b_key)
@@ -775,7 +775,6 @@ fn yield_farm_should_claim_expected_amount() {
                 0
             );
             pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &global_farm_account), 1_000);
-                                                                                                  
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))
         });

--- a/liquidity-mining/src/tests/full_run.rs
+++ b/liquidity-mining/src/tests/full_run.rs
@@ -137,12 +137,12 @@ fn non_full_farm_running_longer_than_expected() {
 
             let claimed_total = alice_claimed + bob_claimed + charlie_claimed;
 
-            assert_eq!(claimed_total.abs_diff(200_000 * ONE), 1);
+            assert_eq!(claimed_total.abs_diff(200_000 * ONE), 1002);
 
             let yield_farm_a_claimed = alice_claimed;
             let yield_farm_b_claimed = bob_claimed + charlie_claimed;
 
-            const TOLERANCE: u128 = 1;
+            const TOLERANCE: u128 = 10;
             assert!(
                 yield_farm_a_claimed.abs_diff(2 * yield_farm_b_claimed).le(&TOLERANCE),
                 "yield_farm_a_claimed == 2 * yield_farm_b_claimed"
@@ -246,13 +246,13 @@ fn non_full_farm_distribute_everything_and_update_farms() {
 
             assert_eq!(
                 Tokens::free_balance(BSX, &LiquidityMining2::farm_account_id(GLOBAL_FARM).unwrap()),
-                0
+                1_000
             );
 
             //NOTE: 1 because we are not able to claim everything becasue us rounding errors
             assert_eq!(
                 Tokens::free_balance(BSX, &LiquidityMining2::pot_account_id().unwrap()),
-                1
+                2
             );
 
             set_block_number(501);
@@ -426,12 +426,12 @@ fn overcrowded_farm_running_longer_than_expected() {
 
             let claimed_total = alice_claimed + bob_claimed + charlie_claimed;
 
-            assert_eq!((200_000 * ONE) - claimed_total, 20); //0.000_000_000_02
+            assert_eq!((200_000 * ONE) - claimed_total, 1_020); //NOTE: ED = 1_000
 
             let yield_farm_a_claimed = alice_claimed;
             let yield_farm_b_claimed = bob_claimed + charlie_claimed;
 
-            const TOLERANCE: u128 = 1;
+            const TOLERANCE: u128 = 10;
             assert!(
                 yield_farm_a_claimed.abs_diff(2 * yield_farm_b_claimed).le(&TOLERANCE),
                 "yield_farm_a_claimed == 2 * yield_farm_b_claimed"
@@ -608,12 +608,12 @@ fn full_farm_running_planned_time() {
 
             let claimed_total = alice_claimed + bob_claimed + charlie_claimed;
 
-            assert_eq!(TOTAL_REWARDS_TO_DISTRIBUTE - claimed_total, 0);
+            assert_eq!(TOTAL_REWARDS_TO_DISTRIBUTE - claimed_total, 1_000);
 
             let yield_farm_a_claimed = alice_claimed;
             let yield_farm_b_claimed = bob_claimed + charlie_claimed;
 
-            const TOLERANCE: u128 = 1;
+            const TOLERANCE: u128 = 10;
             assert!(
                 yield_farm_a_claimed.abs_diff(yield_farm_b_claimed).le(&TOLERANCE),
                 "yield_farm_a_claimed == yield_farm_b_claimed"
@@ -647,6 +647,9 @@ fn yield_farm_should_claim_expected_amount() {
             const PLANNED_PERIODS: u64 = 10_000;
             const BLOCKS_PER_PERIOD: u64 = 10;
             const TOTAL_REWARDS_TO_DISTRIBUTE: u128 = 1_000_000 * ONE;
+
+            let yield_farm_a_key = (BSX_TKN1_AMM, GLOBAL_FARM, YIELD_FARM_A);
+            let yield_farm_b_key = (BSX_TKN2_AMM, GLOBAL_FARM, YIELD_FARM_B);
 
             //initialize farms
             set_block_number(1000);
@@ -712,13 +715,19 @@ fn yield_farm_should_claim_expected_amount() {
             ));
 
             let pot = LiquidityMining2::pot_account_id().unwrap();
-            let farm_a_account = LiquidityMining2::farm_account_id(YIELD_FARM_A).unwrap();
-            let farm_b_account = LiquidityMining2::farm_account_id(YIELD_FARM_B).unwrap();
-
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &farm_b_account), 5_000 * ONE);
-            //NOTE: this farm never claimed from global farm, all the rewards stayed in the pot.
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &farm_a_account), 0);
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &pot), 7_500 * ONE);
+            pretty_assertions::assert_eq!(
+                LiquidityMining2::yield_farm(yield_farm_a_key)
+                    .unwrap()
+                    .left_to_distribute,
+                0 * ONE
+            );
+            pretty_assertions::assert_eq!(
+                LiquidityMining2::yield_farm(yield_farm_b_key)
+                    .unwrap()
+                    .left_to_distribute,
+                5_000 * ONE
+            );
+            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &pot), 12_500 * ONE);
 
             //Global farm had rewards for 100_000 blocks.
             set_block_number(120_000);
@@ -753,9 +762,20 @@ fn yield_farm_should_claim_expected_amount() {
             let global_farm_account = LiquidityMining2::farm_account_id(GLOBAL_FARM).unwrap();
             //leftover because of rounding errors
             pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &pot), 1);
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &farm_a_account), 0);
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &farm_b_account), 1);
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &global_farm_account), 0);
+            pretty_assertions::assert_eq!(
+                LiquidityMining2::yield_farm(yield_farm_a_key)
+                    .unwrap()
+                    .left_to_distribute,
+                0
+            );
+            pretty_assertions::assert_eq!(
+                LiquidityMining2::yield_farm(yield_farm_b_key)
+                    .unwrap()
+                    .left_to_distribute,
+                0
+            );
+            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &global_farm_account), 1_000);
+                                                                                                  
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))
         });

--- a/liquidity-mining/src/tests/invariants.rs
+++ b/liquidity-mining/src/tests/invariants.rs
@@ -106,6 +106,7 @@ prop_compose! {
             multiplier: One::one(),
             state: FarmState::Active,
             entries_count: Default::default(),
+            left_to_distribute: Default::default(),
             _phantom: Default::default(),
         };
 
@@ -231,47 +232,75 @@ proptest! {
     ) {
         new_test_ext().execute_with(|| {
             const GLOBAL_FARM_ID: GlobalFarmId = 1;
-            let yield_farm_account = LiquidityMining::farm_account_id(yield_farm.id).unwrap();
 
-            //rewads for yield farm are paid from pot account
-            let pot_account = LiquidityMining::pot_account_id().unwrap();
-            Tokens::set_balance(Origin::root(), pot_account, REWARD_CURRENCY, left_to_distribute, 0).unwrap();
+            let pot = LiquidityMining::pot_account_id().unwrap();
+            let global_farm_account = LiquidityMining::farm_account_id(GLOBAL_FARM_ID).unwrap();
+            //rewads for yield farm are paid from global-farm's account to pot
+            Tokens::set_balance(Origin::root(), global_farm_account, REWARD_CURRENCY, left_to_distribute, 0).unwrap();
 
             //NOTE: _0 - before action, _1 - after action
-            let pot_balance_0 = Tokens::total_balance(REWARD_CURRENCY, &pot_account);
-            let yield_farm_balance_0 = Tokens::total_balance(REWARD_CURRENCY, &yield_farm_account);
-
-            let accumulated_rpvs_0 = yield_farm.accumulated_rpvs;
+            let pot_balance_0 = Tokens::total_balance(REWARD_CURRENCY, &pot);
+            let global_farm_balance_0 = Tokens::total_balance(REWARD_CURRENCY, &global_farm_account);
 
             LiquidityMining::update_yield_farm(
-                &mut yield_farm, yield_farm_rewards, current_period, GLOBAL_FARM_ID, REWARD_CURRENCY).unwrap();
+                &mut yield_farm, yield_farm_rewards, current_period, GLOBAL_FARM_ID).unwrap();
+
+            let global_farm_balance_1 = Tokens::total_balance(REWARD_CURRENCY, &global_farm_account);
 
             //invariant 1
-            let pot_balance_1 = Tokens::total_balance(REWARD_CURRENCY, &pot_account);
-            let yield_farm_balance_1 = Tokens::total_balance(REWARD_CURRENCY, &yield_farm_account);
-            let s_0 = pot_balance_0 + yield_farm_balance_0;
-            let s_1 = pot_balance_1 + yield_farm_balance_1;
+            //NOTE: yield-farm's rewards are left in the pot until user claims.
+            let pot_balance_1 = Tokens::total_balance(REWARD_CURRENCY, &pot);
+            let s_0 = global_farm_balance_0 + pot_balance_0;
+            let s_1 = global_farm_balance_1 + pot_balance_1;
 
             pretty_assertions::assert_eq!(
                 s_0,
                 s_1,
                 "invariant: `global_farm_balance + yield_farm_balance` is always constant"
-            );
+           );
+        });
+    }
+}
 
-            //invariant 2
-            let s_0 = accumulated_rpvs_0
-                .checked_mul(&FixedU128::from((yield_farm.total_valued_shares, ONE))).unwrap()
-                .checked_add(&FixedU128::from((pot_balance_0, ONE))).unwrap();
-            let s_1 = yield_farm.accumulated_rpvs
-                .checked_mul(&FixedU128::from((yield_farm.total_valued_shares, ONE))).unwrap()
-                .checked_add(&FixedU128::from((pot_balance_1, ONE))).unwrap();
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1_000))]
+    #[test]
+    fn maybe_update_farms(
+        (mut global_farm, mut yield_farm, current_period, _, left_to_distribute) in get_farms_and_current_period_and_yield_farm_rewards_and_lef_to_distribute(),
+    ) {
+        new_test_ext().execute_with(|| {
+            let _ = with_transaction(|| {
+                const GLOBAL_FARM_ID: GlobalFarmId = 1;
 
-            assert_eq_approx!(
-                s_0,
-                s_1,
-                FixedU128::from((TOLERANCE, ONE)),
-                "invariant: global_farm_balance + acc_rpvs * total_valued_shares"
-            );
+                let global_farm_account = LiquidityMining::farm_account_id(GLOBAL_FARM_ID).unwrap();
+                //rewads for yield farm are paid from global-farm's account to pot
+                Tokens::set_balance(Origin::root(), global_farm_account, REWARD_CURRENCY, left_to_distribute, 0).unwrap();
+
+                //NOTE: _0 - before action, _1 - after action
+                let global_farm_balance_0 = Tokens::total_balance(REWARD_CURRENCY, &global_farm_account);
+                let accumulated_rpvs_0 = yield_farm.accumulated_rpvs;
+
+                LiquidityMining::maybe_update_farms(&mut global_farm, &mut yield_farm, current_period).unwrap();
+
+                let global_farm_balance_1 = Tokens::total_balance(REWARD_CURRENCY, &global_farm_account);
+
+                //invariant 2
+                let s_0 = accumulated_rpvs_0
+                    .checked_mul(&FixedU128::from((yield_farm.total_valued_shares, ONE))).unwrap()
+                    .checked_add(&FixedU128::from((global_farm_balance_0, ONE))).unwrap();
+                let s_1 = yield_farm.accumulated_rpvs
+                    .checked_mul(&FixedU128::from((yield_farm.total_valued_shares, ONE))).unwrap()
+                    .checked_add(&FixedU128::from((global_farm_balance_1, ONE))).unwrap();
+
+                assert_eq_approx!(
+                    s_0,
+                    s_1,
+                    FixedU128::from((TOLERANCE, ONE)),
+                    "invariant: global_farm_balance + acc_rpvs * total_valued_shares"
+                );
+
+                TransactionOutcome::Commit(DispatchResult::Ok(()))
+            });
         });
     }
 }

--- a/liquidity-mining/src/tests/mock.rs
+++ b/liquidity-mining/src/tests/mock.rs
@@ -371,9 +371,7 @@ impl DustRemovalAccountWhitelist<AccountId> for Whitelist {
             return Err(sp_runtime::DispatchError::Other("Account is already in the whitelist"));
         }
 
-        DUSTER_WHITELIST.with(|v| {
-            v.borrow_mut().push(*account)
-        });
+        DUSTER_WHITELIST.with(|v| v.borrow_mut().push(*account));
 
         Ok(())
     }
@@ -429,7 +427,7 @@ impl Default for ExtBuilder {
                 (ALICE, BSX_KSM_SHARE_ID, INITIAL_BALANCE),
                 (ALICE, BSX_TKN1_SHARE_ID, 3_000_000),
                 (ALICE, BSX_TKN2_SHARE_ID, 3_000_000),
-                (ALICE, ACA_KSM_SHARE_ID, 3_000_000 ),
+                (ALICE, ACA_KSM_SHARE_ID, 3_000_000),
                 (ALICE, BSX, INITIAL_BALANCE),
                 (ACCOUNT_WITH_1M, BSX, 1_000_000),
                 (BOB, BSX_ACA_SHARE_ID, INITIAL_BALANCE),

--- a/liquidity-mining/src/tests/mock.rs
+++ b/liquidity-mining/src/tests/mock.rs
@@ -22,12 +22,13 @@ use crate as liq_mining;
 use crate::Config;
 use frame_support::{
     parameter_types,
-    traits::{Everything, GenesisBuild, Nothing},
+    traits::Contains,
+    traits::{Everything, GenesisBuild},
     PalletId,
 };
 use frame_system as system;
-use hydradx_traits::{pools::DustRemovalAccountWhitelist, AMM};
-use orml_traits::parameter_type_with_key;
+use hydradx_traits::{pools::DustRemovalAccountWhitelist, Registry, AMM};
+use orml_traits::GetByKey;
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
@@ -84,6 +85,7 @@ pub const DOT: AssetId = 5000;
 pub const ETH: AssetId = 6000;
 pub const TKN1: AssetId = 7_001;
 pub const TKN2: AssetId = 7_002;
+pub const UNKNOWN_ASSET: AssetId = 7_003;
 
 pub const BSX_ACA_AMM: AccountId = 11_000;
 pub const BSX_KSM_AMM: AccountId = 11_001;
@@ -174,15 +176,6 @@ pub struct Amm;
 
 thread_local! {
     pub static AMM_POOLS: RefCell<HashMap<String, (AccountId, AssetId)>> = RefCell::new(HashMap::new());
-
-    //This is used to check if `on_accumulated_rpvs_update()` was called with correct values
-    //`(global_farm_id, yield_farm_id, accumulated_rpvs, total_valued_shares)`
-    pub static RPVS_UPDATED: RefCell<(GlobalFarmId, YieldFarmId, Balance, Balance)> = RefCell::new((0,0,0,0));
-
-    //This is used to check if `on_accumulated_rpz_update()` was called with correct values
-    //`(global_farm_id, accumulated_rpz, total_shares_z)`
-    pub static RPZ_UPDATED: RefCell<(GlobalFarmId, Balance, Balance)> = RefCell::new((0,0,0));
-
     pub static DUSTER_WHITELIST: RefCell<Vec<AccountId>> = RefCell::new(Vec::new());
 }
 
@@ -298,6 +291,7 @@ impl Config<Instance1> for Test {
     type MaxFarmEntriesPerDeposit = MaxEntriesPerDeposit;
     type MaxYieldFarmsPerGlobalFarm = MaxYieldFarmsPerGlobalFarm;
     type NonDustableWhitelistHandler = Whitelist;
+    type AssetRegistry = AssetRegistry;
 }
 
 parameter_types! {
@@ -320,6 +314,7 @@ impl Config<Instance2> for Test {
     type MaxFarmEntriesPerDeposit = MaxEntriesPerDeposit2;
     type MaxYieldFarmsPerGlobalFarm = MaxYieldFarmsPerGlobalFarm;
     type NonDustableWhitelistHandler = Whitelist;
+    type AssetRegistry = AssetRegistry;
 }
 
 parameter_types! {
@@ -340,22 +335,16 @@ impl pallet_balances::Config for Test {
     type ReserveIdentifier = ReserveIdentifier;
 }
 
-parameter_type_with_key! {
-    pub ExistentialDeposits: |_currency_id: AssetId| -> Balance {
-        1u128
-    };
-}
-
 impl orml_tokens::Config for Test {
     type Event = Event;
     type Balance = Balance;
     type Amount = Amount;
     type CurrencyId = AssetId;
     type WeightInfo = ();
-    type ExistentialDeposits = ExistentialDeposits;
+    type ExistentialDeposits = AssetRegistry;
     type OnDust = ();
     type MaxLocks = MaxLocks;
-    type DustRemovalWhitelist = Nothing;
+    type DustRemovalWhitelist = Whitelist;
     type OnKilledTokenAccount = ();
     type OnNewTokenAccount = ();
     type MaxReserves = ConstU32<100_000>;
@@ -364,8 +353,12 @@ impl orml_tokens::Config for Test {
 
 pub struct Whitelist;
 
-impl Whitelist {
-    pub fn contains(account: &AccountId) -> bool {
+impl Contains<AccountId> for Whitelist {
+    fn contains(account: &AccountId) -> bool {
+        if *account == LiquidityMining::pot_account_id().unwrap() {
+            return true;
+        }
+
         DUSTER_WHITELIST.with(|v| v.borrow().contains(account))
     }
 }
@@ -374,7 +367,13 @@ impl DustRemovalAccountWhitelist<AccountId> for Whitelist {
     type Error = DispatchError;
 
     fn add_account(account: &AccountId) -> Result<(), Self::Error> {
-        DUSTER_WHITELIST.with(|v| v.borrow_mut().push(*account));
+        if Whitelist::contains(account) {
+            return Err(sp_runtime::DispatchError::Other("Account is already in the whitelist"));
+        }
+
+        DUSTER_WHITELIST.with(|v| {
+            v.borrow_mut().push(*account)
+        });
 
         Ok(())
     }
@@ -391,6 +390,32 @@ impl DustRemovalAccountWhitelist<AccountId> for Whitelist {
     }
 }
 
+pub struct AssetRegistry;
+
+impl Registry<AssetId, Vec<u8>, Balance, DispatchError> for AssetRegistry {
+    fn exists(name: AssetId) -> bool {
+        name != UNKNOWN_ASSET
+    }
+
+    fn retrieve_asset(_name: &Vec<u8>) -> Result<AssetId, DispatchError> {
+        Err(sp_runtime::DispatchError::Other("NotImplemented"))
+    }
+
+    fn create_asset(_name: &Vec<u8>, _existential_deposit: Balance) -> Result<AssetId, DispatchError> {
+        Err(sp_runtime::DispatchError::Other("NotImplemented"))
+    }
+
+    fn get_or_create_asset(_name: Vec<u8>, _existential_deposit: Balance) -> Result<AssetId, DispatchError> {
+        Err(sp_runtime::DispatchError::Other("NotImplemented"))
+    }
+}
+
+impl GetByKey<AssetId, Balance> for AssetRegistry {
+    fn get(_key: &AssetId) -> Balance {
+        1_000_u128
+    }
+}
+
 pub struct ExtBuilder {
     endowed_accounts: Vec<(AccountId, AssetId, Balance)>,
 }
@@ -404,7 +429,7 @@ impl Default for ExtBuilder {
                 (ALICE, BSX_KSM_SHARE_ID, INITIAL_BALANCE),
                 (ALICE, BSX_TKN1_SHARE_ID, 3_000_000),
                 (ALICE, BSX_TKN2_SHARE_ID, 3_000_000),
-                (ALICE, ACA_KSM_SHARE_ID, 3_000_000),
+                (ALICE, ACA_KSM_SHARE_ID, 3_000_000 ),
                 (ALICE, BSX, INITIAL_BALANCE),
                 (ACCOUNT_WITH_1M, BSX, 1_000_000),
                 (BOB, BSX_ACA_SHARE_ID, INITIAL_BALANCE),
@@ -451,6 +476,9 @@ impl Default for ExtBuilder {
 
 impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
+        AMM_POOLS.with(|v| v.borrow_mut().clear());
+        DUSTER_WHITELIST.with(|v| v.borrow_mut().clear());
+
         let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 
         orml_tokens::GenesisConfig::<Test> {

--- a/liquidity-mining/src/tests/mod.rs
+++ b/liquidity-mining/src/tests/mod.rs
@@ -23,10 +23,10 @@ use mock::{
     BSX_ACA_YIELD_FARM_ID, BSX_DOT_AMM, BSX_DOT_SHARE_ID, BSX_DOT_YIELD_FARM_ID, BSX_ETH_AMM, BSX_ETH_SHARE_ID,
     BSX_FARM, BSX_HDX_AMM, BSX_HDX_SHARE_ID, BSX_KSM_AMM, BSX_KSM_SHARE_ID, BSX_KSM_YIELD_FARM_ID, BSX_TKN1_AMM,
     BSX_TKN1_SHARE_ID, BSX_TKN2_AMM, BSX_TKN2_SHARE_ID, CHARLIE, DAVE, DOT, ETH, EVE, GC, GC_FARM, HDX,
-    INITIAL_BALANCE, KSM, KSM_DOT_AMM, KSM_DOT_SHARE_ID, KSM_FARM, ONE, TKN1, TKN2, TREASURY,
+    INITIAL_BALANCE, KSM, KSM_DOT_AMM, KSM_DOT_SHARE_ID, KSM_FARM, ONE, TKN1, TKN2, TREASURY, UNKNOWN_ASSET,
 };
 
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, traits::Contains};
 
 use sp_arithmetic::traits::CheckedSub;
 use std::cmp::Ordering;
@@ -253,7 +253,7 @@ pub mod create_yield_farm;
 pub mod deposit_lp_shares;
 pub mod destroy_global_farm;
 pub mod destroy_yield_farm;
-pub mod full_run;
+pub mod full_run; //
 pub mod invariants;
 pub mod mock;
 pub mod redeposit_lp_shares;
@@ -263,6 +263,6 @@ pub mod test_ext;
 
 #[allow(clippy::module_inception)]
 pub mod tests;
-pub mod update_global_farm;
+pub mod update_global_farm; 
 pub mod update_yield_farm;
 pub mod withdraw_lp_shares;

--- a/liquidity-mining/src/tests/mod.rs
+++ b/liquidity-mining/src/tests/mod.rs
@@ -18,7 +18,7 @@
 use super::*;
 use mock::{
     asset_pair_to_map_key, set_block_number, with_transaction, AccountId, AssetId, AssetPair, Balance, BlockNumber,
-    ExtBuilder, LiquidityMining, Origin, Test, Tokens, TransactionOutcome, ACA, ACA_FARM, ACA_KSM_AMM,
+    ExtBuilder, LiquidityMining, Origin, Test, Tokens, TransactionOutcome, Whitelist, ACA, ACA_FARM, ACA_KSM_AMM,
     ACA_KSM_SHARE_ID, ACCOUNT_WITH_1M, ALICE, AMM_POOLS, BOB, BSX, BSX_ACA_AMM, BSX_ACA_SHARE_ID,
     BSX_ACA_YIELD_FARM_ID, BSX_DOT_AMM, BSX_DOT_SHARE_ID, BSX_DOT_YIELD_FARM_ID, BSX_ETH_AMM, BSX_ETH_SHARE_ID,
     BSX_FARM, BSX_HDX_AMM, BSX_HDX_SHARE_ID, BSX_KSM_AMM, BSX_KSM_SHARE_ID, BSX_KSM_YIELD_FARM_ID, BSX_TKN1_AMM,

--- a/liquidity-mining/src/tests/mod.rs
+++ b/liquidity-mining/src/tests/mod.rs
@@ -263,6 +263,6 @@ pub mod test_ext;
 
 #[allow(clippy::module_inception)]
 pub mod tests;
-pub mod update_global_farm; 
+pub mod update_global_farm;
 pub mod update_yield_farm;
 pub mod withdraw_lp_shares;

--- a/liquidity-mining/src/tests/resume_yield_farm.rs
+++ b/liquidity-mining/src/tests/resume_yield_farm.rs
@@ -50,7 +50,7 @@ fn resume_yield_farm_should_work() {
                 LiquidityMining::yield_farm((BSX_TKN1_AMM, GC_FARM, GC_BSX_TKN1_YIELD_FARM_ID)).unwrap(),
                 YieldFarmData {
                     state: FarmState::Active,
-                    accumulated_rpz: FixedU128::from_inner(62_987_640_859_560_351_886_455_u128),
+                    accumulated_rpz: FixedU128::from_inner(62_987_638_759_999_160_175_523_u128),
                     multiplier: new_multiplier,
                     updated_at: 134_200,
                     ..yield_farm
@@ -62,8 +62,8 @@ fn resume_yield_farm_should_work() {
                 GlobalFarmData {
                     total_shares_z: global_farm.total_shares_z + yield_farm_stake_in_global_farm,
                     updated_at: 134_200,
-                    accumulated_rpz: FixedU128::from_inner(62_987_640_859_560_351_886_455_u128),
-                    accumulated_rewards: 29_998_716_450,
+                    accumulated_rpz: FixedU128::from_inner(62_987_638_759_999_160_175_523_u128),
+                    accumulated_rewards: 29_998_715_450,
                     ..global_farm
                 }
             );

--- a/liquidity-mining/src/tests/test_ext.rs
+++ b/liquidity-mining/src/tests/test_ext.rs
@@ -233,8 +233,6 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
 
             let global_farm_account = LiquidityMining::farm_account_id(GC_FARM).unwrap();
             let pot_account = LiquidityMining::pot_account_id().unwrap();
-            let bsx_tkn1_yield_farm_account = LiquidityMining::farm_account_id(GC_BSX_TKN1_YIELD_FARM_ID).unwrap();
-            let bsx_tkn2_yield_farm_account = LiquidityMining::farm_account_id(GC_BSX_TKN2_YIELD_FARM_ID).unwrap();
 
             //DEPOSIT 1:
             set_block_number(1_800); //18-th period
@@ -358,6 +356,9 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                 }
             );
 
+            let bsx_tkn1_yield_farm_left_to_distribute = 116_550;
+            let bsx_tkn2_yield_farm_left_to_distribute = 1_167_000;
+
             let yield_farm_id = PREDEFINED_YIELD_FARMS_INS1.with(|v| v[0].id);
             pretty_assertions::assert_eq!(
                 LiquidityMining::yield_farm((BSX_TKN1_AMM, GC_FARM, yield_farm_id)).unwrap(),
@@ -368,6 +369,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                     total_shares: 616,
                     total_valued_shares: 45_540,
                     entries_count: 3,
+                    left_to_distribute: bsx_tkn1_yield_farm_left_to_distribute,
                     ..PREDEFINED_YIELD_FARMS_INS1.with(|v| v[0].clone())
                 },
             );
@@ -382,6 +384,7 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
                     total_shares: 960,
                     total_valued_shares: 47_629,
                     entries_count: 4,
+                    left_to_distribute: bsx_tkn2_yield_farm_left_to_distribute,
                     ..PREDEFINED_YIELD_FARMS_INS1.with(|v| v[1].clone())
                 },
             );
@@ -394,11 +397,10 @@ pub fn predefined_test_ext_with_deposits() -> sp_io::TestExternalities {
             );
 
             //Pot account balance check
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &pot_account), 0);
-
-            //Check of claimed amount from global farm.
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &bsx_tkn1_yield_farm_account), 116_550);
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &bsx_tkn2_yield_farm_account), 1_167_000);
+            pretty_assertions::assert_eq!(
+                Tokens::free_balance(BSX, &pot_account),
+                bsx_tkn1_yield_farm_left_to_distribute + bsx_tkn2_yield_farm_left_to_distribute
+            );
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))
         });

--- a/liquidity-mining/src/tests/tests.rs
+++ b/liquidity-mining/src/tests/tests.rs
@@ -457,7 +457,7 @@ fn update_global_farm_should_work() {
             55_309_798_233_u128,
             71_071_995_u128,
             FixedU128::from_inner(37_740_006_193_817_956_143_u128),
-            3_846_913_3763_u128,
+            38_469_133_763_u128,
         ),
         (
             161_u64,
@@ -1694,9 +1694,7 @@ fn maybe_update_farms_should_work() {
 
             //II. - yield farm has 0 shares and was updated in this period.
             let current_period = 20;
-            let mut yield_farm = YieldFarmData {
-                ..yield_farm_0.clone()
-            };
+            let mut yield_farm = YieldFarmData { ..yield_farm_0.clone() };
             assert_ok!(LiquidityMining::maybe_update_farms(
                 &mut global_farm,
                 &mut yield_farm,

--- a/liquidity-mining/src/tests/tests.rs
+++ b/liquidity-mining/src/tests/tests.rs
@@ -416,9 +416,9 @@ fn update_global_farm_should_work() {
             32_055_u128,
             326_u64,
             1_712_797_u128,
-            61_424_428_u128,
-            FixedU128::from_inner(523_000_000_001_228_236_953_u128),
-            61_456_483_u128,
+            61_455_483_u128,
+            FixedU128::from_inner(523_000_000_001_189_920_405_u128),
+            61_486_538_u128,
         ),
         (
             181_u64,
@@ -456,8 +456,8 @@ fn update_global_farm_should_work() {
             161_u64,
             55_309_798_233_u128,
             71_071_995_u128,
-            FixedU128::from_inner(37_740_007_072_508_302_485_u128),
-            38_469_134_763_u128,
+            FixedU128::from_inner(37_740_006_193_817_956_143_u128),
+            3_846_913_3763_u128,
         ),
         (
             161_u64,
@@ -521,8 +521,8 @@ fn update_global_farm_should_work() {
             131_u64,
             1_081_636_u128,
             75_149_021_u128,
-            FixedU128::from_inner(833_000_000_188_248_661_347_u128),
-            79_001_024_u128,
+            FixedU128::from_inner(833_000_000_188_199_791_016_u128),
+            79_000_024_u128,
         ),
         (
             90_u64,
@@ -638,8 +638,8 @@ fn update_global_farm_should_work() {
             400000_u64,
             886_865_u128,
             52_402_278_u128,
-            FixedU128::from_inner(2_564_373_132_694_355_697_550_585_u128),
-            36_167_851_242_u128,
+            FixedU128::from_inner(2_564_373_061_696_840_610_578_629_u128),
+            36_167_850_242_u128,
         ),
         (
             158_u64,
@@ -697,13 +697,18 @@ fn update_global_farm_should_work() {
         global_farm.paid_accumulated_rewards = 10;
 
         new_test_ext().execute_with(|| {
+            //Add farm's account to whitelist
             let farm_account_id = LiquidityMining::farm_account_id(*id).unwrap();
-            let _ = Tokens::transfer(
+            Whitelist::add_account(&farm_account_id).unwrap();
+
+            Tokens::transfer(
                 Origin::signed(TREASURY),
                 farm_account_id,
                 *reward_currency,
                 *rewards_left_to_distribute,
-            );
+            )
+            .unwrap();
+
             pretty_assertions::assert_eq!(
                 Tokens::free_balance(*reward_currency, &farm_account_id),
                 *rewards_left_to_distribute
@@ -717,8 +722,6 @@ fn update_global_farm_should_work() {
                 ))
             })
             .unwrap();
-
-            //            println!("{}", global_farm.accumulated_rpz);
 
             let mut expected_global_farm = GlobalFarmData::new(
                 *id,
@@ -1152,7 +1155,6 @@ fn update_yield_farm_should_work() {
             299_000_000_000_000_000_000_u128,
             26_u64,
             0_u128,
-            9_000_000_000_000_u128,
         ),
         (
             BSX_FARM,
@@ -1166,7 +1168,6 @@ fn update_yield_farm_should_work() {
             6_188_980_252_477_353_672_176_u128,
             259_u64,
             170_130_593_048_u128,
-            8_829_869_406_952_u128,
         ),
         (
             BSX_FARM,
@@ -1180,7 +1181,6 @@ fn update_yield_farm_should_work() {
             4_053_947_849_148_258_082_137_u128,
             326_u64,
             8_414_312_431_200_u128,
-            585_687_568_800_u128,
         ),
         (
             BSX_FARM,
@@ -1194,7 +1194,6 @@ fn update_yield_farm_should_work() {
             341_317_480_121_125_565_762_u128,
             1856_u64,
             190_581_342_u128,
-            8_999_809_418_658_u128,
         ),
         (
             BSX_FARM,
@@ -1208,7 +1207,6 @@ fn update_yield_farm_should_work() {
             5_738_317_845_151_271_260_056_u128,
             954_u64,
             15_319_968_u128,
-            8_999_984_680_032_u128,
         ),
         (
             BSX_FARM,
@@ -1222,7 +1220,6 @@ fn update_yield_farm_should_work() {
             39_060_859_104_760_294_231_u128,
             161_u64,
             2_345_375_835_u128,
-            8_997_654_624_165_u128,
         ),
         (
             BSX_FARM,
@@ -1236,7 +1233,6 @@ fn update_yield_farm_should_work() {
             1_473_929_331_170_001_802_776_u128,
             448_u64,
             39_735_180_u128,
-            8_999_960_264_820_u128,
         ),
         (
             BSX_FARM,
@@ -1250,7 +1246,6 @@ fn update_yield_farm_should_work() {
             2_530_873_977_086_743_044_189_u128,
             132_u64,
             3_795_224_u128,
-            8_999_996_204_776_u128,
         ),
         (
             BSX_FARM,
@@ -1264,7 +1259,6 @@ fn update_yield_farm_should_work() {
             30_039_394_730_631_530_848_u128,
             146_u64,
             3_249_180_u128,
-            8_999_996_750_820_u128,
         ),
         (
             BSX_FARM,
@@ -1278,7 +1272,6 @@ fn update_yield_farm_should_work() {
             2_134_983_634_885_139_255_946_u128,
             202_u64,
             12_385_881_u128,
-            8_999_987_614_119_u128,
         ),
         (
             BSX_FARM,
@@ -1292,7 +1285,6 @@ fn update_yield_farm_should_work() {
             8_400_705_326_204_672_182_528_u128,
             131_u64,
             56_708_340_909_u128,
-            8_943_291_659_091_u128,
         ),
         (
             BSX_FARM,
@@ -1306,7 +1298,6 @@ fn update_yield_farm_should_work() {
             5_888_827_596_157_395_135_340_u128,
             110_u64,
             1_685_400_u128,
-            8_999_998_314_600_u128,
         ),
         (
             BSX_FARM,
@@ -1320,7 +1311,6 @@ fn update_yield_farm_should_work() {
             2_769_234_905_822_939_172_620_u128,
             582_u64,
             67_232_880_u128,
-            8_999_932_767_120_u128,
         ),
         (
             BSX_FARM,
@@ -1334,7 +1324,6 @@ fn update_yield_farm_should_work() {
             9_756_758_909_090_909_090_909_u128,
             100_u64,
             79_833_261_u128,
-            8_999_920_166_739_u128,
         ),
         (
             BSX_FARM,
@@ -1348,7 +1337,6 @@ fn update_yield_farm_should_work() {
             113_836_422_153_986_125_326_964_u128,
             260_u64,
             3_914_623_276_u128,
-            8_996_085_376_724_u128,
         ),
         (
             BSX_FARM,
@@ -1362,7 +1350,6 @@ fn update_yield_farm_should_work() {
             527_057_655_123_923_360_871_u128,
             229_u64,
             63_144_576_u128,
-            8_999_936_855_424_u128,
         ),
         (
             BSX_FARM,
@@ -1376,7 +1363,6 @@ fn update_yield_farm_should_work() {
             958_332_426_407_246_271_187_u128,
             361_u64,
             179_074_946_u128,
-            8_999_820_925_054_u128,
         ),
         (
             BSX_FARM,
@@ -1390,7 +1376,6 @@ fn update_yield_farm_should_work() {
             128_227_907_000_000_000_000_000_000_u128,
             52_u64,
             256_455_100_u128,
-            8_999_743_544_900_u128,
         ),
         (
             BSX_FARM,
@@ -1404,7 +1389,6 @@ fn update_yield_farm_should_work() {
             13_458_086_594_584_250_310_975_u128,
             132_u64,
             1_119_404_304_u128,
-            8_998_880_595_696_u128,
         ),
         (
             BSX_FARM,
@@ -1418,7 +1402,6 @@ fn update_yield_farm_should_work() {
             2_564_373_000_000_000_000_000_000_u128,
             38_u64,
             0_u128,
-            9_000_000_000_000_u128,
         ),
         (
             BSX_FARM,
@@ -1432,7 +1415,6 @@ fn update_yield_farm_should_work() {
             363_764_930_832_319_503_293_u128,
             159_u64,
             179_074_933_u128,
-            8_999_820_925_067_u128,
         ),
     ];
 
@@ -1448,7 +1430,6 @@ fn update_yield_farm_should_work() {
         expected_yield_farm_accumulated_rpvs,
         expected_updated_at,
         expected_yield_farm_reward_currency_balance,
-        expected_pot_reward_currency_balance,
     ) in testing_values.iter()
     {
         let owner = ALICE;
@@ -1489,14 +1470,15 @@ fn update_yield_farm_should_work() {
             multiplier: FixedU128::from(10_u128),
             state: FarmState::Active,
             entries_count: 0,
+            left_to_distribute: 0,
             _phantom: PhantomData::default(),
         };
 
         let global_farm_account_id = LiquidityMining::farm_account_id(*global_farm_id).unwrap();
         let pot_account_id = LiquidityMining::pot_account_id().unwrap();
-        let yield_farm_account_id = LiquidityMining::farm_account_id(*yield_farm_id).unwrap();
 
         new_test_ext().execute_with(|| {
+            //Arrange
             let _ = Tokens::transfer(
                 Origin::signed(TREASURY),
                 global_farm_account_id,
@@ -1508,23 +1490,24 @@ fn update_yield_farm_should_work() {
                 9_000_000_000_000_u128
             );
 
+            //_0 - value before action
+            let pot_balance_0 = 9_000_000_000_000;
             let _ = Tokens::transfer(
                 Origin::signed(TREASURY),
                 pot_account_id,
                 global_farm.reward_currency,
-                9_000_000_000_000,
+                pot_balance_0,
             );
 
-            pretty_assertions::assert_eq!(Tokens::free_balance(*reward_currency, &yield_farm_account_id), 0);
-
+            //Act
             assert_ok!(LiquidityMining::update_yield_farm(
                 &mut yield_farm,
                 *yield_farm_rewards,
                 *current_period,
                 *global_farm_id,
-                *reward_currency
             ));
 
+            //Assert
             let mut rhs_global_farm = GlobalFarmData::new(
                 *global_farm_id,
                 updated_at,
@@ -1560,18 +1543,15 @@ fn update_yield_farm_should_work() {
                     multiplier: FixedU128::from(10_u128),
                     state: FarmState::Active,
                     entries_count: 0,
+                    left_to_distribute: *expected_yield_farm_reward_currency_balance,
                     _phantom: PhantomData::default(),
                 }
             );
 
-            //rewards for yield farms are tx from pot account
+            //yield-farm's rewards are not transferred from top so it's balance should not change
             pretty_assertions::assert_eq!(
                 Tokens::free_balance(global_farm.reward_currency, &pot_account_id),
-                *expected_pot_reward_currency_balance
-            );
-            pretty_assertions::assert_eq!(
-                Tokens::free_balance(global_farm.reward_currency, &yield_farm_account_id),
-                *expected_yield_farm_reward_currency_balance
+                pot_balance_0
             );
 
             if current_period != yield_farm_updated_at && !yield_farm_total_valued_shares.is_zero() {
@@ -1586,24 +1566,6 @@ fn update_yield_farm_should_work() {
             }
         });
     }
-}
-
-#[test]
-fn update_yield_farm_should_not_work_when_pot_balance_is_not_enough() {
-    new_test_ext().execute_with(|| {
-        let pot = LiquidityMining::pot_account_id().unwrap();
-
-        Tokens::set_balance(Origin::root(), pot, BSX, 1_000 * ONE, Zero::zero()).unwrap();
-
-        let mut yield_farm = YieldFarmData::new(2, 0, None, FixedU128::one());
-        yield_farm.total_shares = ONE;
-        yield_farm.total_valued_shares = ONE;
-
-        assert_noop!(
-            LiquidityMining::update_yield_farm(&mut yield_farm, 2_000 * ONE, 1_000, 1, BSX),
-            Error::<Test, Instance1>::InsufficientPotBalance
-        );
-    });
 }
 
 #[test]
@@ -1664,7 +1626,8 @@ fn maybe_update_farms_should_work() {
     const LEFT_TO_DISTRIBUTE: Balance = 1_000_000_000;
     let reward_currency: AssetId = get_predefined_global_farm_ins1(0).reward_currency;
 
-    let expected_global_farm = GlobalFarmData {
+    //_0 - before action
+    let global_farm_0 = GlobalFarmData {
         updated_at: 20,
         accumulated_rpz: FixedU128::from(20),
         live_yield_farms_count: 1,
@@ -1675,7 +1638,7 @@ fn maybe_update_farms_should_work() {
         ..get_predefined_global_farm_ins1(0)
     };
 
-    let expected_yield_farm = YieldFarmData {
+    let yield_farm_0 = YieldFarmData {
         updated_at: 20,
         total_shares: 200_000,
         total_valued_shares: 400_000,
@@ -1687,6 +1650,8 @@ fn maybe_update_farms_should_work() {
     new_test_ext().execute_with(|| {
         let _ = with_transaction(|| {
             let farm_account_id = LiquidityMining::farm_account_id(get_predefined_global_farm_ins1(0).id).unwrap();
+            Whitelist::add_account(&farm_account_id).unwrap();
+
             Tokens::transfer(
                 Origin::signed(TREASURY),
                 farm_account_id,
@@ -1701,12 +1666,12 @@ fn maybe_update_farms_should_work() {
             );
 
             let mut global_farm = GlobalFarmData {
-                ..expected_global_farm.clone()
+                ..global_farm_0.clone()
             };
 
             let mut yield_farm = YieldFarmData {
                 state: FarmState::Stopped,
-                ..expected_yield_farm.clone()
+                ..yield_farm_0.clone()
             };
 
             let current_period = 30;
@@ -1718,19 +1683,19 @@ fn maybe_update_farms_should_work() {
                 current_period
             ));
 
-            pretty_assertions::assert_eq!(global_farm, expected_global_farm);
+            pretty_assertions::assert_eq!(global_farm, global_farm_0);
             pretty_assertions::assert_eq!(
                 yield_farm,
                 YieldFarmData {
                     state: FarmState::Stopped,
-                    ..expected_yield_farm.clone()
+                    ..yield_farm_0.clone()
                 }
             );
 
             //II. - yield farm has 0 shares and was updated in this period.
             let current_period = 20;
             let mut yield_farm = YieldFarmData {
-                ..expected_yield_farm.clone()
+                ..yield_farm_0.clone()
             };
             assert_ok!(LiquidityMining::maybe_update_farms(
                 &mut global_farm,
@@ -1738,8 +1703,8 @@ fn maybe_update_farms_should_work() {
                 current_period
             ));
 
-            pretty_assertions::assert_eq!(global_farm, expected_global_farm);
-            pretty_assertions::assert_eq!(yield_farm, expected_yield_farm);
+            pretty_assertions::assert_eq!(global_farm, global_farm_0);
+            pretty_assertions::assert_eq!(yield_farm, yield_farm_0);
 
             //III. - global farm has 0 shares and was updated in this period - only yield farm should
             //be updated.
@@ -1747,7 +1712,7 @@ fn maybe_update_farms_should_work() {
             let mut global_farm = GlobalFarmData {
                 total_shares_z: 0,
                 updated_at: 30,
-                ..expected_global_farm.clone()
+                ..global_farm_0.clone()
             };
 
             assert_ok!(LiquidityMining::maybe_update_farms(
@@ -1761,10 +1726,10 @@ fn maybe_update_farms_should_work() {
                 GlobalFarmData {
                     total_shares_z: 0,
                     updated_at: 30,
-                    ..expected_global_farm.clone()
+                    ..global_farm_0.clone()
                 }
             );
-            assert_ne!(yield_farm, expected_yield_farm);
+            assert_ne!(yield_farm, yield_farm_0);
             pretty_assertions::assert_eq!(yield_farm.updated_at, current_period);
 
             //IV. - booth farms met conditions for update
@@ -1775,8 +1740,8 @@ fn maybe_update_farms_should_work() {
                 current_period
             ));
 
-            assert_ne!(global_farm, expected_global_farm);
-            assert_ne!(yield_farm, expected_yield_farm);
+            assert_ne!(global_farm, global_farm_0);
+            assert_ne!(yield_farm, yield_farm_0);
 
             pretty_assertions::assert_eq!(global_farm.updated_at, current_period);
             pretty_assertions::assert_eq!(yield_farm.updated_at, current_period);

--- a/liquidity-mining/src/tests/update_yield_farm.rs
+++ b/liquidity-mining/src/tests/update_yield_farm.rs
@@ -80,13 +80,17 @@ fn update_yield_farm_should_work() {
             //Different period so farms update should happen.
             set_block_number(5_000);
             let new_multiplier: FarmMultiplier = FixedU128::from(5_000_u128);
-            let yield_farm = LiquidityMining::yield_farm((BSX_TKN1_AMM, GC_FARM, GC_BSX_TKN1_YIELD_FARM_ID)).unwrap();
-            let global_farm = LiquidityMining::global_farm(GC_FARM).unwrap();
-
             let global_farm_account = LiquidityMining::farm_account_id(GC_FARM).unwrap();
-            let yield_farm_account = LiquidityMining::farm_account_id(GC_BSX_TKN1_YIELD_FARM_ID).unwrap();
+            let pot = LiquidityMining::pot_account_id().unwrap();
+            let expected_claimed_from_global_farm = 1_498_432_831;
+            let expected_allocated_for_other_yield_farms = 1_567_169; //This is not claimed by
+                                                                      //other yield farms.
 
-            let yield_farm_bsx_balance = Tokens::free_balance(BSX, &yield_farm_account);
+            //_0 - value before action.
+            let yield_farm_0 = LiquidityMining::yield_farm((BSX_TKN1_AMM, GC_FARM, GC_BSX_TKN1_YIELD_FARM_ID)).unwrap();
+            let global_farm_0 = LiquidityMining::global_farm(GC_FARM).unwrap();
+            let global_farm_balance_0 = Tokens::free_balance(BSX, &global_farm_account);
+            let pot_balance_0 = Tokens::free_balance(BSX, &pot);
 
             assert_ok!(LiquidityMining::update_yield_farm_multiplier(
                 GC,
@@ -102,7 +106,8 @@ fn update_yield_farm_should_work() {
                     accumulated_rpvs: FixedU128::from_inner(32_921_163_394_817_742_643_829_u128),
                     accumulated_rpz: FixedU128::from_inner(6_790_366_340_394_671_545_u128),
                     multiplier: new_multiplier,
-                    ..yield_farm
+                    left_to_distribute: yield_farm_0.left_to_distribute + expected_claimed_from_global_farm,
+                    ..yield_farm_0
                 }
             );
 
@@ -112,16 +117,20 @@ fn update_yield_farm_should_work() {
                     updated_at: 50,
                     accumulated_rpz: FixedU128::from_inner(6_790_366_340_394_671_545_u128),
                     total_shares_z: 228_176_290,
-                    accumulated_rewards: global_farm.accumulated_rewards + 1_567_169,
-                    paid_accumulated_rewards: global_farm.paid_accumulated_rewards + 1_498_432_831,
-                    ..global_farm
+                    accumulated_rewards: global_farm_0.accumulated_rewards + expected_allocated_for_other_yield_farms,
+                    paid_accumulated_rewards: global_farm_0.paid_accumulated_rewards
+                        + expected_claimed_from_global_farm,
+                    ..global_farm_0
                 }
             );
 
-            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &global_farm_account), 28_498_716_450);
             pretty_assertions::assert_eq!(
-                Tokens::free_balance(BSX, &yield_farm_account),
-                yield_farm_bsx_balance + 1_498_432_831 //1_498_432_831 - yield farm claim from global farm
+                Tokens::free_balance(BSX, &global_farm_account),
+                global_farm_balance_0 - expected_claimed_from_global_farm - expected_allocated_for_other_yield_farms
+            );
+            pretty_assertions::assert_eq!(
+                Tokens::free_balance(BSX, &pot),
+                pot_balance_0 + expected_claimed_from_global_farm + expected_allocated_for_other_yield_farms
             );
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))

--- a/liquidity-mining/src/tests/withdraw_lp_shares.rs
+++ b/liquidity-mining/src/tests/withdraw_lp_shares.rs
@@ -821,10 +821,7 @@ fn withdraw_shares_from_canceled_yield_farm_should_work() {
                 global_farm_balance_0 + unclaimable_rewards
             );
 
-            pretty_assertions::assert_eq!(
-                Tokens::free_balance(BSX, &pot),
-                pot_balance_0 - unclaimable_rewards
-            );
+            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &pot), pot_balance_0 - unclaimable_rewards);
 
             //2-nd withdraw
             //_0 - value before act.
@@ -832,7 +829,7 @@ fn withdraw_shares_from_canceled_yield_farm_should_work() {
             let pot_balance_0 = Tokens::free_balance(BSX, &pot);
             let global_farm_0 = LiquidityMining::global_farm(GC_FARM).unwrap();
             let yield_farm_0 = LiquidityMining::yield_farm((BSX_TKN1_AMM, GC_FARM, GC_BSX_TKN1_YIELD_FARM_ID)).unwrap();
-            
+
             let unclaimable_rewards = 2_055_086;
             let shares_amount = 486;
             let valued_shares_amount = 38_880;
@@ -868,10 +865,7 @@ fn withdraw_shares_from_canceled_yield_farm_should_work() {
                 global_farm_balance_0 + unclaimable_rewards
             );
 
-            pretty_assertions::assert_eq!(
-                Tokens::free_balance(BSX, &pot),
-                pot_balance_0 - unclaimable_rewards
-            );
+            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &pot), pot_balance_0 - unclaimable_rewards);
 
             //3-th withdraw
             //_0 - value before act.
@@ -914,10 +908,7 @@ fn withdraw_shares_from_canceled_yield_farm_should_work() {
                 global_farm_balance_0 + unclaimable_rewards
             );
 
-            pretty_assertions::assert_eq!(
-                Tokens::free_balance(BSX, &pot),
-                pot_balance_0 - unclaimable_rewards
-            );
+            pretty_assertions::assert_eq!(Tokens::free_balance(BSX, &pot), pot_balance_0 - unclaimable_rewards);
 
             TransactionOutcome::Commit(DispatchResult::Ok(()))
         });

--- a/liquidity-mining/src/tests/withdraw_lp_shares.rs
+++ b/liquidity-mining/src/tests/withdraw_lp_shares.rs
@@ -627,6 +627,13 @@ fn withdraw_with_multiple_entries_and_flush_should_work() {
             assert!(LiquidityMining::yield_farm((BSX_TKN1_AMM, DAVE_FARM, DAVE_BSX_TKN1_YIELD_FARM_ID)).is_none());
             assert!(LiquidityMining::global_farm(DAVE_FARM).is_none());
 
+            //Non-dustable check
+            let global_farm_account = LiquidityMining::farm_account_id(DAVE_FARM).unwrap();
+            pretty_assertions::assert_eq!(Whitelist::contains(&global_farm_account), false);
+
+            let yield_farm_account = LiquidityMining::farm_account_id(DAVE_BSX_TKN1_YIELD_FARM_ID).unwrap();
+            pretty_assertions::assert_eq!(Whitelist::contains(&yield_farm_account), false);
+
             //This withdraw should flush yield and global farms.
             let expected_deposit_destroyed = true;
             pretty_assertions::assert_eq!(

--- a/liquidity-mining/src/types.rs
+++ b/liquidity-mining/src/types.rs
@@ -165,7 +165,8 @@ pub struct YieldFarmData<T: Config<I>, I: 'static = ()> {
     pub(super) multiplier: FarmMultiplier,
     pub(super) state: FarmState,
     pub(super) entries_count: u64,
-    pub(super) _phantom: PhantomData<I>, //pub because of tests
+    pub(super) left_to_distribute: Balance,
+    pub(super) _phantom: PhantomData<I>,
 }
 
 impl<T: Config<I>, I: 'static> YieldFarmData<T, I> {
@@ -187,6 +188,7 @@ impl<T: Config<I>, I: 'static> YieldFarmData<T, I> {
             total_valued_shares: Zero::zero(),
             state: FarmState::Active,
             entries_count: Default::default(),
+            left_to_distribute: Default::default(),
             _phantom: PhantomData::default(),
         }
     }


### PR DESCRIPTION
This PR is adding: 
 * support for nondustable whitelist.
 * integrity test for `MaxFarmEntriesPerDeposit` configuration.
 * `AssetRegistry` - to check if `reward_currency` and `incetivized_asset` are registered and to get information about existential deposit of the tokens.

Nondustable whitelist:
Global-farm’s account is added into the whitelist when a new farm is created and is removed from the whitelist when the farm's owner destroys the farm.

This PR also removes yield-farm’s accounts and replaces it with `YieldFarmData.left_to_distribute` and user’s rewards are transferred directly from the `pot`.

Reason to remove yield-farm’s account is:
Whitelist is not supported by `pallet-balances`used for native currency accounting so to prevent necessity to manage ED on yield-farm’s accounts these accounts were removed. 

There is a single account (`pot`) which always has to have balance > ED in native currency. This should be done before LM starts to be used and should be managed by runtime developers.
`pot` is also added into the whitelist so only native currency ED needs to be managed.

Edge case:
* native currency ED = 10
* global-farm.balance = 11, global-farm’s account is ok
* new ED is set to 20, global-farm account is still ok
* user withdraw lp tokens and `global-farm.balance + user.unclaimable-reward < ED` - account will be dusted.
