### PR TITLE
refactor(nft): remove unused collection types

### DIFF
--- a/nft/src/lib.rs
+++ b/nft/src/lib.rs
@@ -511,7 +511,7 @@ impl<T: Config> InspectEnumerable<T::AccountId> for Pallet<T> {
 }
 
 impl<T: Config> Destroy<T::AccountId> for Pallet<T> {
-    type DestroyWitness = pallet_uniques::DestroyWitness;
+    type DestroyWitness = DestroyWitness;
 
     /// The witness data needed to destroy an item.
     fn get_destroy_witness(collection: &Self::CollectionId) -> Option<Self::DestroyWitness> {

--- a/nft/src/mock.rs
+++ b/nft/src/mock.rs
@@ -18,6 +18,13 @@
 use super::*;
 use crate as pallet_nft;
 
+use frame_support::pallet_prelude::*;
+
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
+use scale_info::TypeInfo;
+
 use frame_support::traits::{AsEnsureOriginWithArg, Everything};
 use frame_support::{parameter_types, weights::Weight};
 use frame_system::EnsureRoot;
@@ -56,41 +63,57 @@ parameter_types! {
     pub ReserveCollectionIdUpTo: u128 = 999;
 }
 
+#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum CollectionTestType {
+    Marketplace = 0_isize,
+    LiquidityMining = 1_isize,
+    Redeemable = 2_isize,
+    Auction = 3_isize,
+    HydraHeads = 4_isize,
+}
+
+impl Default for CollectionTestType {
+    fn default() -> Self {
+        CollectionTestType::Marketplace
+    }
+}
+
 #[derive(Eq, Copy, PartialEq, Clone)]
 pub struct NftTestPermissions;
 
-impl NftPermission<CollectionType> for NftTestPermissions {
-    fn can_create(collection_type: &CollectionType) -> bool {
+impl NftPermission<CollectionTestType> for NftTestPermissions {
+    fn can_create(collection_type: &CollectionTestType) -> bool {
         matches!(
             *collection_type,
-            CollectionType::Marketplace | CollectionType::LiquidityMining | CollectionType::Redeemable
+            CollectionTestType::Marketplace | CollectionTestType::LiquidityMining | CollectionTestType::Redeemable
         )
     }
 
-    fn can_mint(collection_type: &CollectionType) -> bool {
+    fn can_mint(collection_type: &CollectionTestType) -> bool {
         matches!(
             *collection_type,
-            CollectionType::Marketplace | CollectionType::LiquidityMining
+            CollectionTestType::Marketplace | CollectionTestType::LiquidityMining
         )
     }
 
-    fn can_transfer(collection_type: &CollectionType) -> bool {
-        matches!(*collection_type, CollectionType::Marketplace)
+    fn can_transfer(collection_type: &CollectionTestType) -> bool {
+        matches!(*collection_type, CollectionTestType::Marketplace)
     }
 
-    fn can_burn(collection_type: &CollectionType) -> bool {
-        matches!(*collection_type, CollectionType::Marketplace)
+    fn can_burn(collection_type: &CollectionTestType) -> bool {
+        matches!(*collection_type, CollectionTestType::Marketplace)
     }
 
-    fn can_destroy(collection_type: &CollectionType) -> bool {
+    fn can_destroy(collection_type: &CollectionTestType) -> bool {
         matches!(
             *collection_type,
-            CollectionType::Marketplace | CollectionType::LiquidityMining
+            CollectionTestType::Marketplace | CollectionTestType::LiquidityMining
         )
     }
 
-    fn has_deposit(collection_type: &CollectionType) -> bool {
-        matches!(*collection_type, CollectionType::Marketplace)
+    fn has_deposit(collection_type: &CollectionTestType) -> bool {
+        matches!(*collection_type, CollectionTestType::Marketplace)
     }
 }
 
@@ -99,7 +122,7 @@ impl Config for Test {
     type WeightInfo = pallet_nft::weights::BasiliskWeight<Test>;
     type NftCollectionId = CollectionId;
     type NftItemId = ItemId;
-    type CollectionType = CollectionType;
+    type CollectionType = CollectionTestType;
     type Permissions = NftTestPermissions;
     type ReserveCollectionIdUpTo = ReserveCollectionIdUpTo;
 }

--- a/nft/src/mock.rs
+++ b/nft/src/mock.rs
@@ -18,13 +18,6 @@
 use super::*;
 use crate as pallet_nft;
 
-use frame_support::pallet_prelude::*;
-
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
-
-use scale_info::TypeInfo;
-
 use frame_support::traits::{AsEnsureOriginWithArg, Everything};
 use frame_support::{parameter_types, weights::Weight};
 use frame_system::EnsureRoot;
@@ -63,57 +56,32 @@ parameter_types! {
     pub ReserveCollectionIdUpTo: u128 = 999;
 }
 
-#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum CollectionTestType {
-    Marketplace = 0_isize,
-    LiquidityMining = 1_isize,
-    Redeemable = 2_isize,
-    Auction = 3_isize,
-    HydraHeads = 4_isize,
-}
-
-impl Default for CollectionTestType {
-    fn default() -> Self {
-        CollectionTestType::Marketplace
-    }
-}
-
 #[derive(Eq, Copy, PartialEq, Clone)]
 pub struct NftTestPermissions;
 
-impl NftPermission<CollectionTestType> for NftTestPermissions {
-    fn can_create(collection_type: &CollectionTestType) -> bool {
-        matches!(
-            *collection_type,
-            CollectionTestType::Marketplace | CollectionTestType::LiquidityMining | CollectionTestType::Redeemable
-        )
+impl NftPermission<CollectionType> for NftTestPermissions {
+    fn can_create(collection_type: &CollectionType) -> bool {
+        matches!(*collection_type, CollectionType::Marketplace)
     }
 
-    fn can_mint(collection_type: &CollectionTestType) -> bool {
-        matches!(
-            *collection_type,
-            CollectionTestType::Marketplace | CollectionTestType::LiquidityMining
-        )
+    fn can_mint(collection_type: &CollectionType) -> bool {
+        matches!(*collection_type, CollectionType::Marketplace)
     }
 
-    fn can_transfer(collection_type: &CollectionTestType) -> bool {
-        matches!(*collection_type, CollectionTestType::Marketplace)
+    fn can_transfer(collection_type: &CollectionType) -> bool {
+        matches!(*collection_type, CollectionType::Marketplace)
     }
 
-    fn can_burn(collection_type: &CollectionTestType) -> bool {
-        matches!(*collection_type, CollectionTestType::Marketplace)
+    fn can_burn(collection_type: &CollectionType) -> bool {
+        matches!(*collection_type, CollectionType::Marketplace)
     }
 
-    fn can_destroy(collection_type: &CollectionTestType) -> bool {
-        matches!(
-            *collection_type,
-            CollectionTestType::Marketplace | CollectionTestType::LiquidityMining
-        )
+    fn can_destroy(collection_type: &CollectionType) -> bool {
+        matches!(*collection_type, CollectionType::Marketplace)
     }
 
-    fn has_deposit(collection_type: &CollectionTestType) -> bool {
-        matches!(*collection_type, CollectionTestType::Marketplace)
+    fn has_deposit(collection_type: &CollectionType) -> bool {
+        matches!(*collection_type, CollectionType::Marketplace)
     }
 }
 
@@ -122,7 +90,7 @@ impl Config for Test {
     type WeightInfo = pallet_nft::weights::BasiliskWeight<Test>;
     type NftCollectionId = CollectionId;
     type NftItemId = ItemId;
-    type CollectionType = CollectionTestType;
+    type CollectionType = CollectionType;
     type Permissions = NftTestPermissions;
     type ReserveCollectionIdUpTo = ReserveCollectionIdUpTo;
 }

--- a/nft/src/tests.rs
+++ b/nft/src/tests.rs
@@ -37,7 +37,7 @@ fn create_collection_works() {
         assert_eq!(
             NFTPallet::collections(COLLECTION_ID_0).unwrap(),
             CollectionInfo {
-                collection_type: CollectionType::Marketplace,
+                collection_type: CollectionTestType::Marketplace,
                 metadata: metadata.clone()
             }
         );
@@ -45,7 +45,7 @@ fn create_collection_works() {
         expect_events(vec![crate::Event::CollectionCreated {
             owner: ALICE,
             collection_id: COLLECTION_ID_0,
-            collection_type: CollectionType::Marketplace,
+            collection_type: CollectionTestType::Marketplace,
             metadata: metadata.clone(),
         }
         .into()]);
@@ -55,7 +55,7 @@ fn create_collection_works() {
             NFTPallet::create_collection(
                 Origin::signed(ALICE),
                 COLLECTION_ID_2,
-                CollectionType::Auction,
+                CollectionTestType::Auction,
                 metadata.clone()
             ),
             Error::<Test>::NotPermitted
@@ -66,7 +66,7 @@ fn create_collection_works() {
             NFTPallet::create_collection(
                 Origin::signed(ALICE),
                 COLLECTION_ID_0,
-                CollectionType::LiquidityMining,
+                CollectionTestType::LiquidityMining,
                 metadata.clone()
             ),
             pallet_uniques::Error::<Test>::InUse
@@ -77,7 +77,7 @@ fn create_collection_works() {
             NFTPallet::create_collection(
                 Origin::signed(ALICE),
                 COLLECTION_ID_RESERVED,
-                CollectionType::Marketplace,
+                CollectionTestType::Marketplace,
                 metadata
             ),
             Error::<Test>::IdReserved
@@ -100,7 +100,7 @@ fn mint_works() {
         assert_ok!(NFTPallet::create_collection(
             Origin::signed(ALICE),
             COLLECTION_ID_1,
-            CollectionType::Redeemable,
+            CollectionTestType::Redeemable,
             metadata.clone()
         ));
 
@@ -166,7 +166,7 @@ fn transfer_works() {
         assert_ok!(NFTPallet::create_collection(
             Origin::signed(ALICE),
             COLLECTION_ID_1,
-            CollectionType::LiquidityMining,
+            CollectionTestType::LiquidityMining,
             metadata.clone()
         ));
         assert_ok!(NFTPallet::mint(
@@ -241,7 +241,7 @@ fn burn_works() {
         assert_ok!(NFTPallet::create_collection(
             Origin::signed(ALICE),
             COLLECTION_ID_1,
-            CollectionType::LiquidityMining,
+            CollectionTestType::LiquidityMining,
             metadata.clone()
         ));
         assert_ok!(NFTPallet::mint(
@@ -302,7 +302,7 @@ fn destroy_collection_works() {
         assert_ok!(NFTPallet::create_collection(
             Origin::signed(ALICE),
             COLLECTION_ID_1,
-            CollectionType::Redeemable,
+            CollectionTestType::Redeemable,
             metadata.clone()
         ));
         assert_ok!(NFTPallet::mint(
@@ -356,7 +356,7 @@ fn deposit_works() {
         assert_ok!(NFTPallet::create_collection(
             Origin::signed(ALICE),
             COLLECTION_ID_0,
-            CollectionType::Marketplace,
+            CollectionTestType::Marketplace,
             metadata.clone()
         ));
         assert_eq!(
@@ -379,7 +379,7 @@ fn deposit_works() {
         assert_ok!(NFTPallet::create_collection(
             Origin::signed(ALICE),
             COLLECTION_ID_0,
-            CollectionType::LiquidityMining,
+            CollectionTestType::LiquidityMining,
             metadata
         ));
         assert_eq!(
@@ -799,13 +799,13 @@ fn create_typed_collection_should_work_without_deposit_when_deposit_is_not_requi
         assert_ok!(NFTPallet::create_typed_collection(
             ACCOUNT_WITH_NO_BALANCE,
             COLLECTION_ID_0,
-            CollectionType::LiquidityMining
+            CollectionTestType::LiquidityMining
         ));
 
         assert_eq!(
             NFTPallet::collections(COLLECTION_ID_0).unwrap(),
             CollectionInfoOf::<Test> {
-                collection_type: CollectionType::LiquidityMining,
+                collection_type: CollectionTestType::LiquidityMining,
                 metadata: Default::default()
             }
         )
@@ -818,13 +818,13 @@ fn create_typed_collection_should_work_with_reserved_id() {
         assert_ok!(NFTPallet::create_typed_collection(
             ALICE,
             COLLECTION_ID_RESERVED,
-            CollectionType::LiquidityMining
+            CollectionTestType::LiquidityMining
         ));
 
         assert_eq!(
             NFTPallet::collections(COLLECTION_ID_RESERVED).unwrap(),
             CollectionInfoOf::<Test> {
-                collection_type: CollectionType::LiquidityMining,
+                collection_type: CollectionTestType::LiquidityMining,
                 metadata: Default::default()
             }
         )
@@ -835,7 +835,11 @@ fn create_typed_collection_should_work_with_reserved_id() {
 fn create_typed_collection_should_not_work_without_deposit_when_deposit_is_required() {
     ExtBuilder::default().build().execute_with(|| {
         assert_noop!(
-            NFTPallet::create_typed_collection(ACCOUNT_WITH_NO_BALANCE, COLLECTION_ID_0, CollectionType::Marketplace),
+            NFTPallet::create_typed_collection(
+                ACCOUNT_WITH_NO_BALANCE,
+                COLLECTION_ID_0,
+                CollectionTestType::Marketplace
+            ),
             pallet_balances::Error::<Test>::InsufficientBalance
         );
     });
@@ -848,7 +852,7 @@ fn do_mint_should_work_when_account_has_no_balance() {
         assert_ok!(NFTPallet::create_typed_collection(
             ACCOUNT_WITH_NO_BALANCE,
             COLLECTION_ID_0,
-            CollectionType::LiquidityMining
+            CollectionTestType::LiquidityMining
         ));
 
         //act & assert
@@ -867,7 +871,7 @@ fn burn_should_work_when_account_has_no_balance() {
         assert_ok!(NFTPallet::create_typed_collection(
             ACCOUNT_WITH_NO_BALANCE,
             COLLECTION_ID_0,
-            CollectionType::LiquidityMining
+            CollectionTestType::LiquidityMining
         ));
 
         assert_ok!(NFTPallet::mint_into(
@@ -961,7 +965,7 @@ fn do_destroy_collection_works() {
         assert_ok!(NFTPallet::create_collection(
             Origin::signed(ALICE),
             COLLECTION_ID_1,
-            CollectionType::Redeemable,
+            CollectionTestType::Redeemable,
             metadata
         ));
 

--- a/nft/src/types.rs
+++ b/nft/src/types.rs
@@ -48,9 +48,6 @@ pub struct ItemInfo<BoundedVec> {
 pub enum CollectionType {
     Marketplace = 0_isize,
     LiquidityMining = 1_isize,
-    Redeemable = 2_isize,
-    Auction = 3_isize,
-    HydraHeads = 4_isize,
 }
 
 impl Default for CollectionType {


### PR DESCRIPTION
Remove unused collection types: `Redeemable`, `Auction` and `HydraHeads`. Use `CollectionTestType` with old fields in the tests to keep the tests untouched (and testing all test cases).