### PR TITLE
add .devcontainer to provide a Rust env for github codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,6 @@ COPY . .
 
 RUN bash ./setup.sh
 
-RUN bash ./build-deps.sh
-
 ENV PATH="/root/.cargo/bin:$PATH"
+
+RUN zsh ./setup-cargo.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04
+
+WORKDIR /home/
+
+COPY . .
+
+RUN bash ./setup.sh
+
+RUN bash ./build-deps.sh
+
+ENV PATH="/root/.cargo/bin:$PATH"

--- a/.devcontainer/build-deps.sh
+++ b/.devcontainer/build-deps.sh
@@ -1,2 +1,0 @@
-
-cargo build-deps

--- a/.devcontainer/build-deps.sh
+++ b/.devcontainer/build-deps.sh
@@ -1,0 +1,2 @@
+
+cargo build-deps

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "Codespaces Rust Starter",
+	"extensions": [
+		"cschleiden.vscode-github-actions",
+		"ms-vsliveshare.vsliveshare",
+		"matklad.rust-analyzer",
+		"serayuzgur.crates",
+		"vadimcn.vscode-lldb"
+	],
+	"dockerFile": "Dockerfile",
+	"settings": {
+		"editor.formatOnSave": true,
+		"terminal.integrated.shell.linux": "/usr/bin/zsh",
+		"files.exclude": {
+			"**/CODE_OF_CONDUCT.md": true,
+			"**/LICENSE": true
+		}
+	}
+}

--- a/.devcontainer/setup-cargo.sh
+++ b/.devcontainer/setup-cargo.sh
@@ -1,0 +1,4 @@
+
+cargo install cargo-expand
+cargo install cargo-edit
+cargo install cargo-nextest

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -24,11 +24,6 @@ rustup component add rustfmt --toolchain nightly
 rustup component add clippy 
 rustup component add clippy --toolchain nightly
 
-cargo install cargo-expand
-cargo install cargo-edit
-cargo install cargo-nextest
-cargo install cargo-build-deps
-
 ## setup and install oh-my-zsh
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 cp -R /root/.oh-my-zsh /home/$USERNAME

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,37 @@
+## update and install some things we should probably have
+apt-get update
+apt-get install -y \
+  curl \
+  git \
+  gnupg2 \
+  jq \
+  sudo \
+  zsh \
+  vim \
+  build-essential \
+  openssl
+
+# install gmp deps
+apt-get install -y cmake m4
+# install rocksdb deps
+apt-get install -y libclang-10-dev
+
+## Install rustup and common components
+curl https://sh.rustup.rs -sSf | sh -s -- -y 
+rustup install nightly
+rustup component add rustfmt
+rustup component add rustfmt --toolchain nightly
+rustup component add clippy 
+rustup component add clippy --toolchain nightly
+
+cargo install cargo-expand
+cargo install cargo-edit
+cargo install cargo-nextest
+cargo install cargo-build-deps
+
+## setup and install oh-my-zsh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+cp -R /root/.oh-my-zsh /home/$USERNAME
+cp /root/.zshrc /home/$USERNAME
+sed -i -e "s/\/root\/.oh-my-zsh/\/home\/$USERNAME\/.oh-my-zsh/g" /home/$USERNAME/.zshrc
+chown -R $USER_UID:$USER_GID /home/$USERNAME/.oh-my-zsh /home/$USERNAME/.zshrc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # warehouse
 Collection of reusable pallets and crates used in Basilisk and HydraDX projects.
+
+### Codespaces Integration
+Feel free to spin up a codespace instance by going to "Code > Codespaces".
+It will have a Rust environment ready to go so you can just do `cargo test` (or `cargo nextest run`).


### PR DESCRIPTION
### Description
Adds a Rust devcontainer for use with Github Codespaces.
After merging this you should be able to just drop into a codespace of the repo by clicking on the green "Code" button on the repo main page, choosing "Codespaces" and then picking a branch.
Main usecases I see:
- working on a quick fix that is more complex than a typo (and so needs a dev environment)
- working on the repo if you don't have access to your dev env
- working on sth in parallel while waiting for compilation on your main machine :sweat_smile: 

### Limitations
+ It's surprisingly complex to prebuild dependencies, so compile time is not the best when first starting a codespace.
+ The commits are not verified.