### PR TITLE
extend asset registry genesis config to allow specifying ids at genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-registry"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/asset-registry/Cargo.toml
+++ b/asset-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-asset-registry"
-version = "1.4.0"
+version = "2.0.0"
 description = "Pallet for asset registry management"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/asset-registry/src/lib.rs
+++ b/asset-registry/src/lib.rs
@@ -162,6 +162,7 @@ pub mod pallet {
     #[pallet::genesis_config]
     pub struct GenesisConfig<T: Config> {
         pub asset_names: Vec<(Vec<u8>, T::Balance)>,
+        pub asset_ids: Vec<(Vec<u8>, T::Balance, T::AssetId)>,
         pub native_asset_name: Vec<u8>,
         pub native_existential_deposit: T::Balance,
     }
@@ -171,6 +172,7 @@ pub mod pallet {
         fn default() -> Self {
             GenesisConfig::<T> {
                 asset_names: vec![],
+                asset_ids: vec![],
                 native_asset_name: b"BSX".to_vec(),
                 native_existential_deposit: Default::default(),
             }
@@ -200,6 +202,14 @@ pub mod pallet {
                     .map_err(|_| panic!("Invalid asset name!"))
                     .unwrap();
                 let _ = Pallet::<T>::register_asset(bounded_name, AssetType::Token, *ed, None)
+                    .map_err(|_| panic!("Failed to register asset"));
+            });
+
+            self.asset_ids.iter().for_each(|(name, ed, id)| {
+                let bounded_name = Pallet::<T>::to_bounded_name(name.to_vec())
+                    .map_err(|_| panic!("Invalid asset name!"))
+                    .unwrap();
+                let _ = Pallet::<T>::register_asset(bounded_name, AssetType::Token, *ed, Some(*id))
                     .map_err(|_| panic!("Failed to register asset"));
             })
         }

--- a/asset-registry/src/mock.rs
+++ b/asset-registry/src/mock.rs
@@ -54,7 +54,7 @@ parameter_types! {
     pub const SS58Prefix: u8 = 63;
     pub const NativeAssetId: AssetId = 0;
     pub const RegistryStringLimit: u32 = 10;
-    pub const SequentailIdStart: u32 = 1_000_000;
+    pub const SequentialIdStart: u32 = 1_000_000;
 }
 
 impl system::Config for Test {
@@ -103,7 +103,7 @@ impl Config for Test {
     type Balance = Balance;
     type AssetNativeLocation = AssetLocation;
     type StringLimit = RegistryStringLimit;
-    type SequentialIdStartAt = SequentailIdStart;
+    type SequentialIdStartAt = SequentialIdStart;
     type NativeAssetId = NativeAssetId;
     type WeightInfo = ();
 }
@@ -112,12 +112,18 @@ pub type AssetRegistryPallet = crate::Pallet<Test>;
 #[derive(Default)]
 pub struct ExtBuilder {
     assets: Vec<(Vec<u8>, Balance)>,
+    asset_ids: Vec<(Vec<u8>, Balance, AssetId)>,
     native_asset_name: Option<Vec<u8>>,
 }
 
 impl ExtBuilder {
     pub fn with_assets(mut self, assets: Vec<(Vec<u8>, Balance)>) -> Self {
         self.assets = assets;
+        self
+    }
+
+    pub fn with_asset_ids(mut self, asset_ids: Vec<(Vec<u8>, Balance, AssetId)>) -> Self {
+        self.asset_ids = asset_ids;
         self
     }
 
@@ -132,12 +138,14 @@ impl ExtBuilder {
         if let Some(name) = self.native_asset_name {
             crate::GenesisConfig::<Test> {
                 asset_names: self.assets,
+                asset_ids: self.asset_ids,
                 native_asset_name: name,
                 native_existential_deposit: 1_000_000u128,
             }
         } else {
             crate::GenesisConfig::<Test> {
                 asset_names: self.assets,
+                asset_ids: self.asset_ids,
                 ..Default::default()
             }
         }


### PR DESCRIPTION
This is useful for e.g. integration tests where we might want to set e.g. `LRNA` at genesis to have a certain asset id.