### PR TITLE
feat: return amm_pool_id from redeposit_lp_shares

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,7 +2835,7 @@ name = "hydradx-adapters"
 version = "0.2.2"
 dependencies = [
  "frame-support",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "lazy_static",
  "log",
  "pallet-transaction-multi-payment",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-traits"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -4717,7 +4717,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-traits",
  "parity-scale-codec",
  "primitive-types 0.12.1",
@@ -5122,14 +5122,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquidity-mining"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "fixed",
  "frame-support",
  "frame-system",
  "hydra-dx-math 5.1.4",
  "hydradx-traits 0.9.1",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-currencies",
  "orml-tokens",
  "orml-traits",
@@ -5218,7 +5218,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-utilities",
  "pallet-balances",
  "pallet-uniques",
@@ -5300,7 +5300,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -5347,7 +5347,7 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "hydradx-adapters",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-tokens",
  "orml-traits",
  "pallet-balances",
@@ -5408,7 +5408,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hydra-dx-math 4.9.0",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-tokens",
  "orml-traits",
  "parity-scale-codec",
@@ -5495,7 +5495,7 @@ version = "8.0.4"
 dependencies = [
  "frame-support",
  "frame-system",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-tokens",
  "orml-traits",
  "pallet-balances",

--- a/liquidity-mining/Cargo.toml
+++ b/liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-liquidity-mining"
-version = "2.0.1"
+version = "3.0.0"
 description = "Liquidity mining"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/liquidity-mining/src/lib.rs
+++ b/liquidity-mining/src/lib.rs
@@ -1049,7 +1049,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         yield_farm_id: YieldFarmId,
         deposit_id: DepositId,
         get_token_value_of_lp_shares: fn(T::AssetId, T::AmmPoolId, Balance) -> Result<Balance, DispatchError>,
-    ) -> Result<Balance, DispatchError> {
+    ) -> Result<(Balance, T::AmmPoolId), DispatchError> {
         <Deposit<T, I>>::try_mutate(deposit_id, |maybe_deposit| {
             //NOTE: At this point deposit existence and owner must be checked by pallet calling this
             //function so this should never happen.
@@ -1059,7 +1059,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
             Self::do_deposit_lp_shares(deposit, global_farm_id, yield_farm_id, get_token_value_of_lp_shares)?;
 
-            Ok(deposit.shares)
+            Ok((deposit.shares, deposit.amm_pool_id.clone()))
         })
     }
 
@@ -1863,7 +1863,7 @@ impl<T: Config<I>, I: 'static> hydradx_traits::liquidity_mining::Mutate<T::Accou
             Self::AmmPoolId,
             Self::Balance,
         ) -> Result<Self::Balance, Self::Error>,
-    ) -> Result<Self::Balance, Self::Error> {
+    ) -> Result<(Self::Balance, Self::AmmPoolId), Self::Error> {
         Self::redeposit_lp_shares(global_farm_id, yield_farm_id, deposit_id, get_token_value_of_lp_shares)
     }
 

--- a/liquidity-mining/src/lib.rs
+++ b/liquidity-mining/src/lib.rs
@@ -1036,7 +1036,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
     ///
     /// This function DOESN'T create new deposit.
     ///
-    /// Returns: `(redeposited shares amount)`
+    /// Returns: `(redeposited shares amount, amm pool id)`
     ///
     /// Parameters:
     /// - `global_farm_id`: global farm identifier.

--- a/liquidity-mining/src/tests/redeposit_lp_shares.rs
+++ b/liquidity-mining/src/tests/redeposit_lp_shares.rs
@@ -33,7 +33,7 @@ fn redeposit_lp_shares_should_work() {
                     |_, _, _| { Ok(500 * ONE) }
                 )
                 .unwrap(),
-                50 * ONE
+                (50 * ONE, BSX_TKN1_AMM)
             );
 
             assert_eq!(
@@ -53,7 +53,7 @@ fn redeposit_lp_shares_should_work() {
                     |_, _, _| { Ok(5_000 * ONE) }
                 )
                 .unwrap(),
-                50 * ONE
+                (50 * ONE, BSX_TKN1_AMM)
             );
 
             assert_eq!(

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-traits"
-version = "1.0.0"
+version = "2.0.0"
 description = "Shared traits"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/traits/src/liquidity_mining.rs
+++ b/traits/src/liquidity_mining.rs
@@ -107,14 +107,14 @@ pub trait Mutate<AccountId, AssetId, BlockNumber> {
 
     /// Redeposit already locked LP shares to another yield farm.
     ///
-    /// Returns: `(redeposited LP shares amount)`
+    /// Returns: `(redeposited LP shares amount, amm pool id)`
     #[allow(clippy::type_complexity)]
     fn redeposit_lp_shares(
         global_farm_id: GlobalFarmId,
         yield_farm_id: YieldFarmId,
         deposit_id: DepositId,
         get_token_value_of_lp_shares: fn(AssetId, Self::AmmPoolId, Self::Balance) -> Result<Self::Balance, Self::Error>,
-    ) -> Result<Self::Balance, Self::Error>;
+    ) -> Result<(Self::Balance, Self::AmmPoolId), Self::Error>;
 
     /// Claim rewards for given deposit.
     ///


### PR DESCRIPTION
This PR updates liquidity-mining's `redeposit_lp_shares()` function to return also `amm_pool_id`. This change is necessary for Basilisk's xyk-liqudity-mining pallet to correctly validate `AssetPair` param from user.