### PR TITLE
feat: simple amm sim for property tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf688625d06217d5b1bb0ea9d9c44a1635fd0ee3534466388d18203174f4d11"
 
 [[package]]
+name = "amm-simulator"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ name = "amm-simulator"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "sp-arithmetic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
 	"stableswap",
 	"test-utils",
 	"duster",
+	"amm-simulator",
 ]
 
 resolver = "2"

--- a/amm-simulator/Cargo.toml
+++ b/amm-simulator/Cargo.toml
@@ -7,3 +7,9 @@ edition = "2021"
 
 [dependencies]
 proptest = "1.0.0"
+sp-arithmetic= { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false}
+
+
+[features]
+default = ["std"]
+std = []

--- a/amm-simulator/Cargo.toml
+++ b/amm-simulator/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "amm-simulator"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proptest = "1.0.0"

--- a/amm-simulator/src/lib.rs
+++ b/amm-simulator/src/lib.rs
@@ -1,0 +1,124 @@
+#[cfg(test)]
+mod tests;
+
+use proptest::prelude::*;
+use proptest::prop_oneof;
+use proptest::test_runner::{Config as PropConfig, FileFailurePersistence, TestError, TestRunner};
+
+pub trait Interface {
+    fn prepare(pool: PoolState);
+
+    fn before_execute(&mut self);
+    fn execute(d: u128);
+    fn after_execute(&mut self);
+}
+
+pub enum PoolType<AssetId> {
+    TwoAsset,
+    TwoAssetWith(AssetId),
+}
+
+pub enum TradeType {
+    Any,
+    SinglePool,
+}
+
+pub struct Config {
+    pool_type: PoolType<u32>,
+    trade_type: TradeType,
+    max_reserve: u128,
+    asset_ids: Vec<u32>,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct PoolState {
+    asset_a: u32,
+    asset_b: u32,
+    reserve_a: u128,
+    reserve_b: u128,
+}
+
+#[macro_export]
+macro_rules! decl_amm {
+    (
+		pub struct $name:ident {
+			Amm = $runtime:path,
+			Config = $config:expr,
+		}
+	) => {
+        pub struct $name;
+
+        impl $name {
+            pub fn execute_sell(&self) {
+                let mut runner = TestRunner::new(PropConfig {
+                    // Turn failure persistence off for demonstration
+                    failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
+                    ..PropConfig::default()
+                });
+                let result = runner.run(&(pool_state_and_trade_amount(&$config)), |(amount, state)| {
+                    <$runtime>::prepare(state);
+                    $runtime.before_execute();
+                    <$runtime>::execute(amount);
+                    $runtime.after_execute();
+                    Ok(())
+                });
+
+                println!("I did this too!");
+            }
+        }
+    };
+}
+
+fn decimals() -> impl Strategy<Value = u32> {
+    prop_oneof![Just(6), Just(8), Just(10), Just(12), Just(18),]
+}
+
+fn pool_state(config: &Config) -> impl Strategy<Value = PoolState> {
+    (asset_reserve(config.max_reserve), asset_reserve(config.max_reserve)).prop_map(|(reserve_a, reserve_b)| {
+        PoolState {
+            asset_a: 0,
+            asset_b: 1,
+            reserve_a,
+            reserve_b,
+        }
+    })
+
+    /*
+    match config.pool_type {
+        PoolType::TwoAsset => todo!(),
+        PoolType::TwoAssetWith(asset_id) => {
+            asset_reserve(config.max_reserve).prop_map(|reserve|PoolState{
+                asset_a: 0,
+                asset_b: asset_id.clone(),
+                reserve_a: reserve.clone(),
+                reserve_b: reserve.clone(),
+            })
+        }
+    }
+
+         */
+}
+
+prop_compose! {
+    fn asset_reserve(max_amount: u128)
+                    (prec in decimals())
+                    (reserve in 1.. max_amount * 10u128.pow(prec)) -> u128 {
+        reserve
+    }
+}
+
+prop_compose! {
+    fn reserve_and_trade_amount(config: &Config)
+                    (reserve in asset_reserve(config.max_reserve))
+                    (amount in 1.. reserve / 3, reserve in Just(reserve)) -> (u128, u128) {
+        (reserve, amount)
+    }
+}
+
+prop_compose! {
+    fn pool_state_and_trade_amount(config: &Config)
+                    (pool in pool_state(config))
+                    (amount in 1.. pool.reserve_a / 3, pool in Just(pool)) -> (u128, PoolState) {
+        (amount, pool)
+    }
+}

--- a/amm-simulator/src/lib.rs
+++ b/amm-simulator/src/lib.rs
@@ -15,7 +15,7 @@ pub trait Interface {
 
 pub enum PoolType<AssetId> {
     TwoAsset,
-    TwoAssetWith(AssetId),
+    TwoAssetWith(AssetId, u32),
 }
 
 pub enum TradeType {
@@ -96,11 +96,11 @@ fn pools(config: &Config) -> BoxedStrategy<Vec<PoolState>> {
             }
             r.boxed()
         }
-        PoolType::TwoAssetWith(asset_id) => {
+        PoolType::TwoAssetWith(asset_id, prec) => {
             let mut r = vec![];
             for asset in config.asset_ids.iter().filter(|id| **id != asset_id) {
                 let a = *asset;
-                let p = (asset_reserve(config.max_reserve), asset_reserve(config.max_reserve)).prop_map(
+                let p = (asset_reserve(config.max_reserve), asset_reserve_with_prec(config.max_reserve, prec)).prop_map(
                     move |(reserve_a, reserve_b)| PoolState {
                         asset_a: a,
                         asset_b: asset_id,
@@ -150,6 +150,9 @@ prop_compose! {
                     -> ( (u32,u32,u128) ,  Vec<PoolState>) {
         ((pool.asset_a, pool.asset_b, amount), state)
     }
+}
+fn asset_reserve_with_prec(max_amount: u128, prec: u32) -> impl Strategy<Value = u128> {
+    1.. max_amount * 10u128.pow(prec)
 }
 
 prop_compose! {

--- a/amm-simulator/src/lib.rs
+++ b/amm-simulator/src/lib.rs
@@ -1,173 +1,144 @@
 #[cfg(test)]
 mod tests;
+mod types;
+pub use types::*;
 
 use proptest::prelude::*;
 use proptest::prop_oneof;
-use proptest::test_runner::{Config as PropConfig, FileFailurePersistence, TestError, TestRunner};
 
 pub trait Interface {
-    fn prepare(pool: Vec<PoolState>);
-
-    fn before_execute(&mut self);
-    fn execute(asset_in: u32, asset_out: u32, amount: u128);
-    fn after_execute(&mut self);
-    fn validate_sell(&self);
-}
-
-pub enum PoolType<AssetId> {
-    TwoAsset,
-    TwoAssetWith(AssetId, u32),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TradeType {
-    Any,
-    SinglePool,
-}
-
-pub struct Config {
-    pool_type: PoolType<u32>,
-    trade_type: TradeType,
-    max_reserve: u128,
-    asset_ids: Vec<u32>,
-    max_trade_ratio: u8,
-}
-
-#[derive(Default, Debug, Clone, Copy)]
-pub struct PoolState {
-    asset_a: u32,
-    asset_b: u32,
-    reserve_a: u128,
-    reserve_b: u128,
+	fn execute(state: Vec<PoolState>, asset_in: u32, asset_out: u32, amount: u128);
 }
 
 #[macro_export]
-macro_rules! decl_amm {
-    (
+macro_rules! decl_amm_sim {
+	(
 		pub struct $name:ident {
 			Amm = $runtime:path,
 			Config = $config:expr,
 		}
 	) => {
-        pub struct $name;
+		use proptest::test_runner::{Config as PropConfig, FileFailurePersistence, TestRunner};
+		pub struct $name;
 
-        impl $name {
-            pub fn execute_sell(&self) {
-                let mut runner = TestRunner::new(PropConfig {
-                    // Turn failure persistence off for demonstration
-                    failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
-                    ..PropConfig::default()
-                });
-                let result = runner.run(
-                    &(initial_state_and_trade_amount(&$config, $config.trade_type)),
-                    |((asset_in, asset_out, amount), state)| {
-                        <$runtime>::prepare(state);
-                        $runtime.before_execute();
-                        <$runtime>::execute(asset_in, asset_out, amount);
-                        $runtime.after_execute();
-                        $runtime.validate_sell();
-                        Ok(())
-                    },
-                );
-            }
-        }
-    };
+		impl $name {
+			pub fn execute(&self) {
+				let mut runner = TestRunner::new(PropConfig {
+					failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
+					cases: 1000,
+					..PropConfig::default()
+				});
+				let result = runner.run(
+					&(initial_state_and_trade_amount(&$config, $config.trade_type)),
+					|((asset_in, asset_out, amount), state)| {
+						<$runtime>::execute(state, asset_in, asset_out, amount);
+						Ok(())
+					},
+				);
+
+				if let Err(value) = result {
+					println!("Minimal failing input: {:?}", value);
+				}
+			}
+		}
+	};
 }
 
 fn decimals() -> impl Strategy<Value = u32> {
-    prop_oneof![Just(6), Just(8), Just(10), Just(12), Just(18),]
+	prop_oneof![Just(6), Just(8), Just(10), Just(12), Just(18)]
 }
 
 fn pools(config: &Config) -> BoxedStrategy<Vec<PoolState>> {
-    match config.pool_type {
-        PoolType::TwoAsset => {
-            let mut r = vec![];
-            for assets in config.asset_ids.windows(2) {
-                let a = assets[0];
-                let b = assets[1];
-                let p = (asset_reserve(config.max_reserve), asset_reserve(config.max_reserve)).prop_map(
-                    move |(reserve_a, reserve_b)| PoolState {
-                        asset_a: a,
-                        asset_b: b,
-                        reserve_a,
-                        reserve_b,
-                    },
-                );
-                r.push(p);
-            }
-            r.boxed()
-        }
-        PoolType::TwoAssetWith(asset_id, prec) => {
-            let mut r = vec![];
-            for asset in config.asset_ids.iter().filter(|id| **id != asset_id) {
-                let a = *asset;
-                let p = (
-                    asset_reserve(config.max_reserve),
-                    asset_reserve_with_prec(config.max_reserve, prec),
-                )
-                    .prop_map(move |(reserve_a, reserve_b)| PoolState {
-                        asset_a: a,
-                        asset_b: asset_id,
-                        reserve_a,
-                        reserve_b,
-                    });
-                r.push(p);
-            }
-            r.boxed()
-        }
-    }
+	match config.pool_type {
+		PoolType::TwoAsset => {
+			let mut r = vec![];
+			for assets in config.asset_ids.windows(2) {
+				let a = assets[0];
+				let b = assets[1];
+				let p = (asset_reserve(config.max_reserve), asset_reserve(config.max_reserve)).prop_map(
+					move |(reserve_a, reserve_b)| PoolState {
+						asset_a: a,
+						asset_b: b,
+						reserve_a,
+						reserve_b,
+					},
+				);
+				r.push(p);
+			}
+			r.boxed()
+		}
+		PoolType::TwoAssetWith(asset_id, prec) => {
+			let mut r = vec![];
+			for asset in config.asset_ids.iter()
+			{
+				let a = *asset;
+				let p = (
+					asset_reserve(config.max_reserve),
+					asset_reserve_with_prec(config.max_reserve, prec),
+				)
+					.prop_map(move |(reserve_a, reserve_b)| PoolState {
+						asset_a: a,
+						asset_b: asset_id,
+						reserve_a,
+						reserve_b,
+					});
+				r.push(p);
+			}
+			r.boxed()
+		}
+	}
 }
 
 fn select_trade_assets(
-    state: Vec<PoolState>,
-    trade_type: TradeType,
+	state: Vec<PoolState>,
+	trade_type: TradeType,
 ) -> impl Strategy<Value = (u32, u32, u128, Vec<PoolState>)> {
-    let len = state.len();
+	let len = state.len() - 1;
 
-    (0..len, 0..len).prop_map(move |(idx1, idx2)| match trade_type {
-        TradeType::SinglePool => (
-            state[idx1].asset_a,
-            state[idx1].asset_b,
-            state[idx1].reserve_a,
-            state.clone(),
-        ),
-        TradeType::Any => (
-            state[idx1].asset_a,
-            state[idx2].asset_a,
-            state[idx1].reserve_a,
-            state.clone(),
-        ),
-    })
+	(2..len, 2..len).prop_map(move |(idx1, idx2)| match trade_type {
+		TradeType::SinglePool => (
+			state[idx1].asset_a,
+			state[idx1].asset_b,
+			state[idx1].reserve_a,
+			state.clone(),
+		),
+		TradeType::Any => (
+			state[idx1].asset_a,
+			state[idx2].asset_a,
+			state[idx1].reserve_a,
+			state.clone(),
+		),
+	})
 }
 
 fn trade(max_amount: u128, max_ratio: u8) -> impl Strategy<Value = u128> {
-    0..max_amount / max_ratio as u128
+	1..(max_amount / max_ratio as u128)
 }
 
 prop_compose! {
-    fn initial_state_and_trade_assets(config: &Config, trade_type: TradeType)
-                    (state in pools(config))
-                    ((asset_in, asset_out, max_in, state) in select_trade_assets(state, trade_type)) -> ((u32,u32,u128), Vec<PoolState>) {
-        ((asset_in,asset_out, max_in), state)
-    }
+	pub fn initial_state_and_trade_assets(config: &Config, trade_type: TradeType)
+					(state in pools(config))
+					((asset_in, asset_out, max_in, state) in select_trade_assets(state, trade_type)) -> ((u32,u32,u128), Vec<PoolState>) {
+		((asset_in,asset_out, max_in), state)
+	}
 }
 
 prop_compose! {
-    fn initial_state_and_trade_amount(config: &Config, trade_type: TradeType)
-                    (((asset_in,asset_out, max_in), state) in initial_state_and_trade_assets(config, trade_type))
-                    (amount in trade(max_in, 3 ), (asset_in, asset_out,state) in Just((asset_in, asset_out, state)))
-                    -> ( (u32,u32,u128) ,  Vec<PoolState>) {
-        ((asset_in, asset_out, amount), state)
-    }
+	pub fn initial_state_and_trade_amount(config: &Config, trade_type: TradeType)
+					(((asset_in,asset_out, max_in), state) in initial_state_and_trade_assets(config, trade_type))
+					(amount in trade(max_in, 4 ), (asset_in, asset_out,state) in Just((asset_in, asset_out, state)))
+					-> ( (u32,u32,u128) ,  Vec<PoolState>) {
+		((asset_in, asset_out, amount), state)
+	}
 }
 fn asset_reserve_with_prec(max_amount: u128, prec: u32) -> impl Strategy<Value = u128> {
-    1..max_amount * 10u128.pow(prec)
+	1_000..max_amount * 10u128.pow(prec)
 }
 
 prop_compose! {
-    fn asset_reserve(max_amount: u128)
-                    (prec in decimals())
-                    (reserve in 1.. max_amount * 10u128.pow(prec)) -> u128 {
-        reserve
-    }
+	fn asset_reserve(max_amount: u128)
+					(prec in decimals())
+					(reserve in 1.. max_amount * 10u128.pow(prec)) -> u128 {
+		reserve
+	}
 }

--- a/amm-simulator/src/tests.rs
+++ b/amm-simulator/src/tests.rs
@@ -4,7 +4,7 @@ pub struct SomeAmm;
 fn sim_config() -> Config {
     Config {
         pool_type: PoolType::TwoAssetWith(1, 12),
-        trade_type: TradeType::Any,
+        trade_type: TradeType::SinglePool,
         max_reserve: 1,
         asset_ids: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         max_trade_ratio: 3,

--- a/amm-simulator/src/tests.rs
+++ b/amm-simulator/src/tests.rs
@@ -1,0 +1,35 @@
+use super::*;
+pub struct SomeAmm;
+
+fn sim_config() -> Config {
+    Config {
+        pool_type: PoolType::TwoAssetWith(1),
+        trade_type: TradeType::Any,
+        max_reserve: 1,
+        asset_ids: vec![0],
+    }
+}
+
+impl Interface for SomeAmm {
+    fn prepare(pool: PoolState) {
+        dbg!(pool);
+    }
+
+    fn before_execute(&mut self) {}
+
+    fn execute(v: u128) {}
+
+    fn after_execute(&mut self) {}
+}
+
+decl_amm!(
+    pub struct AmmSim{
+        Amm = SomeAmm,
+        Config = sim_config(),
+    }
+);
+
+#[test]
+fn test_declare() {
+    AmmSim.execute_sell();
+}

--- a/amm-simulator/src/tests.rs
+++ b/amm-simulator/src/tests.rs
@@ -6,18 +6,21 @@ fn sim_config() -> Config {
         pool_type: PoolType::TwoAssetWith(1),
         trade_type: TradeType::Any,
         max_reserve: 1,
-        asset_ids: vec![0],
+        asset_ids: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        max_trade_ratio: 3,
     }
 }
 
 impl Interface for SomeAmm {
-    fn prepare(pool: PoolState) {
+    fn prepare(pool: Vec<PoolState>) {
         dbg!(pool);
     }
 
     fn before_execute(&mut self) {}
 
-    fn execute(v: u128) {}
+    fn execute(asset_in: u32, asset_out: u32, amount: u128) {
+        dbg!(asset_in, asset_out, amount);
+    }
 
     fn after_execute(&mut self) {}
 }

--- a/amm-simulator/src/tests.rs
+++ b/amm-simulator/src/tests.rs
@@ -3,7 +3,7 @@ pub struct SomeAmm;
 
 fn sim_config() -> Config {
     Config {
-        pool_type: PoolType::TwoAssetWith(1),
+        pool_type: PoolType::TwoAssetWith(1, 12),
         trade_type: TradeType::Any,
         max_reserve: 1,
         asset_ids: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],

--- a/amm-simulator/src/tests.rs
+++ b/amm-simulator/src/tests.rs
@@ -2,39 +2,29 @@ use super::*;
 pub struct SomeAmm;
 
 fn sim_config() -> Config {
-    Config {
-        pool_type: PoolType::TwoAssetWith(1, 12),
-        trade_type: TradeType::SinglePool,
-        max_reserve: 1,
-        asset_ids: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        max_trade_ratio: 3,
-    }
+	Config {
+		pool_type: PoolType::TwoAssetWith(1, 12),
+		trade_type: TradeType::Any,
+		max_reserve: 1,
+		asset_ids: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+		max_trade_ratio: 3,
+	}
 }
 
 impl Interface for SomeAmm {
-    fn prepare(pool: Vec<PoolState>) {
-        dbg!(pool);
-    }
-
-    fn before_execute(&mut self) {}
-
-    fn execute(asset_in: u32, asset_out: u32, amount: u128) {
-        dbg!(asset_in, asset_out, amount);
-    }
-
-    fn after_execute(&mut self) {}
-
-    fn validate_sell(&self) {}
+	fn execute(_state: Vec<PoolState>, _asset_in: u32, _asset_out: u32, _amount: u128) {
+		//dbg!(asset_in, asset_out, amount);
+	}
 }
 
-decl_amm!(
-    pub struct AmmSim{
-        Amm = SomeAmm,
-        Config = sim_config(),
-    }
+decl_amm_sim!(
+	pub struct AmmSim{
+		Amm = SomeAmm,
+		Config = sim_config(),
+	}
 );
 
 #[test]
 fn test_declare() {
-    AmmSim.execute_sell();
+	AmmSim.execute();
 }

--- a/amm-simulator/src/tests.rs
+++ b/amm-simulator/src/tests.rs
@@ -23,6 +23,8 @@ impl Interface for SomeAmm {
     }
 
     fn after_execute(&mut self) {}
+
+    fn validate_sell(&self) {}
 }
 
 decl_amm!(

--- a/amm-simulator/src/types.rs
+++ b/amm-simulator/src/types.rs
@@ -1,0 +1,35 @@
+use sp_arithmetic::FixedU128;
+
+#[derive(Debug)]
+pub enum PoolType<AssetId> {
+	TwoAsset,
+	TwoAssetWith(AssetId, u32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TradeType {
+	Any,
+	SinglePool,
+}
+
+pub struct Config {
+	pub pool_type: PoolType<u32>,
+	pub trade_type: TradeType,
+	pub max_reserve: u128,
+	pub asset_ids: Vec<u32>,
+	pub max_trade_ratio: u8,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct PoolState {
+	pub asset_a: u32,
+	pub asset_b: u32,
+	pub reserve_a: u128,
+	pub reserve_b: u128,
+}
+
+impl PoolState {
+	pub fn price(&self) -> FixedU128 {
+		FixedU128::from_rational(self.reserve_b, self.reserve_a)
+	}
+}


### PR DESCRIPTION
This PR introduces very simple amm sim to easily create property tests or invariants tests for AMMs.

It is initial POC, some more work will follow, however, with current state, it is already usable and additional stuff can be added as new feature requests.

