### PR TITLE
chore: add new oracle period

### DIFF
--- a/ema-oracle/src/benchmarking.rs
+++ b/ema-oracle/src/benchmarking.rs
@@ -30,9 +30,6 @@ use pretty_assertions::assert_eq;
 
 use crate::Pallet as EmaOracle;
 
-/// Maximum parameter to run the benchmark for.
-pub const MAX_TOKEN_PAIRS: u32 = MAX_UNIQUE_ENTRIES - 1;
-
 /// Default oracle source.
 const SOURCE: Source = *b"dummysrc";
 
@@ -106,7 +103,7 @@ benchmarks! {
     }
 
     on_finalize_multiple_tokens {
-        let b in 1 .. MAX_TOKEN_PAIRS;
+        let b in 1 .. (T::MaxUniqueEntries::get() - 1);
 
         let initial_data_block: T::BlockNumber = 5u32.into();
         let block_num = initial_data_block.saturating_add(1_000_000u32.into());
@@ -146,7 +143,7 @@ benchmarks! {
     }
 
     on_trade_multiple_tokens {
-        let b in 1 .. MAX_TOKEN_PAIRS;
+        let b in 1 .. (T::MaxUniqueEntries::get() - 1);
 
         let initial_data_block: T::BlockNumber = 5u32.into();
         let block_num = initial_data_block.saturating_add(1_000_000u32.into());
@@ -196,7 +193,7 @@ benchmarks! {
     }
 
     on_liquidity_changed_multiple_tokens {
-        let b in 1 .. MAX_TOKEN_PAIRS;
+        let b in 1 .. (T::MaxUniqueEntries::get() - 1);
 
         let initial_data_block: T::BlockNumber = 5u32.into();
         let block_num = initial_data_block.saturating_add(1_000_000u32.into());

--- a/ema-oracle/src/benchmarking.rs
+++ b/ema-oracle/src/benchmarking.rs
@@ -269,7 +269,10 @@ benchmarks! {
 
         let res = core::cell::RefCell::new(Err(OracleError::NotPresent));
 
-    }: { let _ = res.replace(EmaOracle::<T>::get_entry(asset_a, asset_b, TenMinutes, SOURCE)); }
+        // aim to find a period that is not `LastBlock`, falling back to `LastBlock` if none is found.
+        let period = T::SupportedPeriods::get().into_iter().find(|p| p != &LastBlock).unwrap_or(LastBlock);
+
+    }: { let _ = res.replace(EmaOracle::<T>::get_entry(asset_a, asset_b, period, SOURCE)); }
     verify {
         assert_eq!(*res.borrow(), Ok(AggregatedEntry {
             price: Price::from((amount_in, amount_out)),

--- a/ema-oracle/src/tests/mock.rs
+++ b/ema-oracle/src/tests/mock.rs
@@ -40,7 +40,7 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 use crate::MAX_PERIODS;
-use crate::MAX_UNIQUE_ENTRIES;
+
 pub const HDX: AssetId = 1_000;
 pub const DOT: AssetId = 2_000;
 pub const ACA: AssetId = 3_000;
@@ -133,7 +133,7 @@ impl Config for Test {
     type WeightInfo = ();
     type BlockNumberProvider = System;
     type SupportedPeriods = SupportedPeriods;
-    type MaxUniqueEntries = ConstU32<MAX_UNIQUE_ENTRIES>;
+    type MaxUniqueEntries = ConstU32<45>;
 }
 
 pub type InitialDataEntry = (Source, (AssetId, AssetId), Price, Liquidity<Balance>);

--- a/ema-oracle/src/tests/mod.rs
+++ b/ema-oracle/src/tests/mod.rs
@@ -258,7 +258,7 @@ fn on_trade_should_exclude_zero_values() {
 #[test]
 fn on_entry_should_error_on_accumulator_overflow() {
     new_test_ext().execute_with(|| {
-        let max_entries = MAX_UNIQUE_ENTRIES;
+        let max_entries = <<Test as crate::Config>::MaxUniqueEntries as Get<u32>>::get();
         // let's fill the accumulator
         for i in 0..max_entries {
             assert_ok!(OnActivityHandler::<Test>::on_trade(

--- a/ema-oracle/src/tests/mod.rs
+++ b/ema-oracle/src/tests/mod.rs
@@ -715,22 +715,26 @@ fn check_period_smoothing_factors() {
     let days = 24 * hours;
 
     let last_block = smoothing_from_period(1);
-    println!("Last Block: {}", last_block.to_bits());
+    println!("Last Block: {} (bits: {})", last_block, last_block.to_bits());
     assert_eq!(into_smoothing(LastBlock), last_block);
 
+    let short = smoothing_from_period(9);
+    println!("Short: {} (bits: {})", short, short.to_bits());
+    assert_eq!(into_smoothing(Short), short);
+
     let ten_minutes = smoothing_from_period(10 * minutes);
-    println!("Ten Minutes: {}", ten_minutes.to_bits());
+    println!("Ten Minutes: {} (bits: {})", ten_minutes, ten_minutes.to_bits());
     assert_eq!(into_smoothing(TenMinutes), ten_minutes);
 
     let hour = smoothing_from_period(hours);
-    println!("Hour: {}", hour.to_bits());
+    println!("Hour: {} (bits: {})", hour, hour.to_bits());
     assert_eq!(into_smoothing(Hour), hour);
 
     let day = smoothing_from_period(days);
-    println!("Day: {}", day.to_bits());
+    println!("Day: {} (bits: {})", day, day.to_bits());
     assert_eq!(into_smoothing(Day), day);
 
     let week = smoothing_from_period(7 * days);
-    println!("Week: {}", week.to_bits());
+    println!("Week: {} (bits: {})", week, week.to_bits());
     assert_eq!(into_smoothing(Week), week);
 }

--- a/ema-oracle/src/types.rs
+++ b/ema-oracle/src/types.rs
@@ -198,6 +198,7 @@ where
 pub fn into_smoothing(period: OraclePeriod) -> Fraction {
     match period {
         OraclePeriod::LastBlock => Fraction::from_bits(170141183460469231731687303715884105728),
+        OraclePeriod::Short => Fraction::from_bits(34028236692093846346337460743176821146),
         OraclePeriod::TenMinutes => Fraction::from_bits(3369132345751865974884897103284833777),
         OraclePeriod::Hour => Fraction::from_bits(566193622164623067326746434994622648),
         OraclePeriod::Day => Fraction::from_bits(23629079016800115510268356880200556),

--- a/traits/src/oracle.rs
+++ b/traits/src/oracle.rs
@@ -34,6 +34,8 @@ where
 pub enum OraclePeriod {
     /// The oracle data is from the last block, thus unaggregated.
     LastBlock,
+    /// The oracle data was aggregated over the last few blocks.
+    Short,
     /// The oracle data was aggregated over the blocks of the last ten minutes.
     TenMinutes,
     /// The oracle data was aggregated over the blocks of the last hour.


### PR DESCRIPTION
This PR adds a new oracle period with a = 0.2 (which corresponds to a 9 block oracle when calculating with `smoothing_from_period`).

Based on #182 