### PR TITLE
fix: Use Liquidity for Price Calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ema-oracle"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/ema-oracle/Cargo.toml
+++ b/ema-oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-ema-oracle'
-version = '0.1.0'
+version = '1.0.0'
 description = 'Exponential moving average oracle for AMM pools'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/ema-oracle/src/benchmarking.rs
+++ b/ema-oracle/src/benchmarking.rs
@@ -56,7 +56,7 @@ benchmarks! {
         let (liquidity_asset_in, liquidity_asset_out) = (1_000_000_000_000_000, 2_000_000_000_000_000);
         assert_ok!(OnActivityHandler::<T>::on_trade(SOURCE, HDX, DOT, amount_in, amount_out, liquidity_asset_in, liquidity_asset_out));
         let entry = OracleEntry {
-            price: Price::from((amount_in, amount_out)),
+            price: Price::from((liquidity_asset_in, liquidity_asset_out)),
             volume: Volume::from_a_in_b_out(amount_in, amount_out),
             liquidity: Liquidity::new(liquidity_asset_in, liquidity_asset_out),
             timestamp: block_num,
@@ -88,7 +88,7 @@ benchmarks! {
 
         assert_ok!(OnActivityHandler::<T>::on_trade(SOURCE, HDX, DOT, amount_in, amount_out, liquidity_asset_in, liquidity_asset_out));
         let entry = OracleEntry {
-            price: Price::from((amount_in, amount_out)),
+            price: Price::from((liquidity_asset_in, liquidity_asset_out)),
             volume: Volume::from_a_in_b_out(amount_in, amount_out),
             liquidity: Liquidity::new(liquidity_asset_in, liquidity_asset_out),
             timestamp: block_num,
@@ -129,7 +129,7 @@ benchmarks! {
     }: { EmaOracle::<T>::on_finalize(block_num); }
     verify {
         let entry = OracleEntry {
-            price: Price::from((amount_in, amount_out)),
+            price: Price::from((liquidity_asset_in, liquidity_asset_out)),
             volume: Volume::from_a_in_b_out(amount_in, amount_out),
             liquidity: Liquidity::new(liquidity_asset_in, liquidity_asset_out),
             timestamp: block_num,
@@ -164,7 +164,7 @@ benchmarks! {
         frame_system::Pallet::<T>::set_block_number(block_num);
         EmaOracle::<T>::on_initialize(block_num);
         let entry = OracleEntry {
-            price: Price::from((amount_in, amount_out)),
+            price: Price::from((liquidity_asset_in, liquidity_asset_out)),
             volume: Volume::from_a_in_b_out(amount_in, amount_out),
             liquidity: Liquidity::new(liquidity_asset_in, liquidity_asset_out),
             timestamp: block_num,
@@ -214,7 +214,7 @@ benchmarks! {
         frame_system::Pallet::<T>::set_block_number(block_num);
         EmaOracle::<T>::on_initialize(block_num);
         let entry = OracleEntry {
-            price: Price::from((amount_a, amount_b)),
+            price: Price::from((liquidity_asset_a, liquidity_asset_b)),
             volume: Volume::from_a_in_b_out(amount_a, amount_b),
             liquidity: Liquidity::new(liquidity_asset_a, liquidity_asset_b),
             timestamp: block_num,
@@ -273,7 +273,7 @@ benchmarks! {
     }: { let _ = res.replace(EmaOracle::<T>::get_entry(asset_a, asset_b, period, SOURCE)); }
     verify {
         assert_eq!(*res.borrow(), Ok(AggregatedEntry {
-            price: Price::from((amount_in, amount_out)),
+            price: Price::from((liquidity_asset_in, liquidity_asset_out)),
             volume: Volume::default(),
             liquidity: Liquidity::new(liquidity_asset_in, liquidity_asset_out),
             oracle_age,

--- a/ema-oracle/src/lib.rs
+++ b/ema-oracle/src/lib.rs
@@ -393,10 +393,10 @@ impl<T: Config> OnTradeHandler<AssetId, Balance> for OnActivityHandler<T> {
     ) -> Result<Weight, (Weight, DispatchError)> {
         // We assume that zero values are not valid and can be ignored.
         if liquidity_a.is_zero() || liquidity_b.is_zero() || amount_a.is_zero() || amount_b.is_zero() {
-            log::warn!(target: LOG_TARGET, "Neither liquidity nor amounts should be zero. Ignoring. Source: {source:?}, liquidity: ({liquidity_a},{liquidity_a}) , amount_a/_out: {amount_a}/{amount_b}");
+            log::warn!(target: LOG_TARGET, "Neither liquidity nor amounts should be zero. Source: {source:?}, liquidity: ({liquidity_a},{liquidity_b}), amounts: {amount_a}/{amount_b}");
             return Err((Self::on_trade_weight(), Error::<T>::OnTradeValueZero.into()));
         }
-        let price = determine_normalized_price(asset_a, asset_b, amount_a, amount_b);
+        let price = determine_normalized_price(asset_a, asset_b, liquidity_a, liquidity_b);
         let volume = determine_normalized_volume(asset_a, asset_b, amount_a, amount_b);
         let liquidity = determine_normalized_liquidity(asset_a, asset_b, liquidity_a, liquidity_b);
 

--- a/ema-oracle/src/tests/invariants.rs
+++ b/ema-oracle/src/tests/invariants.rs
@@ -152,7 +152,7 @@ proptest! {
             let oracle_age: u32 = 98;
             System::set_block_number(u64::from(oracle_age) + 2);
             let smoothing = into_smoothing(LastBlock);
-            let price = Price::new(amount_hdx, amount_dot);
+            let price = Price::new(liquidity_hdx, liquidity_dot);
             let volume = (amount_hdx, amount_dot, 0, 0);
             let expected = AggregatedEntry {
                 price: iterated_price_ema(oracle_age, price, price, smoothing),

--- a/ema-oracle/src/tests/mock.rs
+++ b/ema-oracle/src/tests/mock.rs
@@ -46,7 +46,7 @@ pub const DOT: AssetId = 2_000;
 pub const ACA: AssetId = 3_000;
 
 pub const ORACLE_ENTRY_1: OracleEntry<BlockNumber> = OracleEntry {
-    price: Price::new(1_000, 500),
+    price: Price::new(2_000, 1_000),
     volume: Volume {
         a_in: 1_000,
         b_out: 500,
@@ -57,7 +57,7 @@ pub const ORACLE_ENTRY_1: OracleEntry<BlockNumber> = OracleEntry {
     timestamp: 5,
 };
 pub const ORACLE_ENTRY_2: OracleEntry<BlockNumber> = OracleEntry {
-    price: Price::new(2_000, 2_000),
+    price: Price::new(4_000, 4_000),
     volume: Volume {
         a_in: 0,
         b_out: 0,

--- a/ema-oracle/src/tests/mod.rs
+++ b/ema-oracle/src/tests/mod.rs
@@ -166,6 +166,25 @@ fn on_liquidity_changed_handler_should_work() {
 }
 
 #[test]
+fn price_should_be_determined_from_liquidity() {
+    new_test_ext().execute_with(|| {
+        assert_eq!(get_accumulator_entry(SOURCE, (HDX, DOT)), None);
+        assert_ok!(OnActivityHandler::<Test>::on_liquidity_changed(
+            SOURCE, HDX, DOT, 5, 1, 2_000_000, 1_000_000
+        ));
+        let expected = Price::new(2_000_000, 1_000_000);
+        assert_eq!(get_accumulator_entry(SOURCE, (HDX, DOT)).unwrap().price, expected);
+
+        assert_eq!(get_accumulator_entry(SOURCE, (DOT, ACA)), None);
+        assert_ok!(OnActivityHandler::<Test>::on_trade(
+            SOURCE, DOT, ACA, 1234, 789, 5_000_000, 500
+        ));
+        let expected = Price::new(5_000_000, 500);
+        assert_eq!(get_accumulator_entry(SOURCE, (DOT, ACA)).unwrap().price, expected);
+    });
+}
+
+#[test]
 fn on_liquidity_changed_should_allow_zero_values() {
     let timestamp = 5;
     let (liquidity_a, liquidity_b) = (2_000, 1_000);

--- a/ema-oracle/src/tests/mod.rs
+++ b/ema-oracle/src/tests/mod.rs
@@ -131,12 +131,18 @@ fn on_trade_should_work() {
 #[test]
 fn on_trade_handler_should_work() {
     new_test_ext().execute_with(|| {
-        System::set_block_number(ORACLE_ENTRY_1.timestamp);
+        System::set_block_number(5);
         assert_eq!(get_accumulator_entry(SOURCE, (HDX, DOT)), None);
         assert_ok!(OnActivityHandler::<Test>::on_trade(
             SOURCE, HDX, DOT, 1_000, 500, 2_000, 1_000
         ));
-        assert_eq!(get_accumulator_entry(SOURCE, (HDX, DOT)), Some(ORACLE_ENTRY_1));
+        let expected = OracleEntry {
+            price: Price::new(2_000, 1_000),
+            volume: Volume::from_a_in_b_out(1_000, 500),
+            liquidity: Liquidity::new(2_000, 1_000),
+            timestamp: 5,
+        };
+        assert_eq!(get_accumulator_entry(SOURCE, (HDX, DOT)), Some(expected));
     });
 }
 
@@ -319,13 +325,13 @@ fn oracle_volume_should_factor_in_asset_order() {
 
         let price_entry = get_accumulator_entry(SOURCE, (HDX, DOT)).unwrap();
         let first_entry = OracleEntry {
-            price: Price::new(2_000_000, 1_000),
+            price: Price::new(2_000, 1),
             volume: Volume::from_a_in_b_out(2_000_000, 1_000),
             liquidity: (2_000, 1).into(),
             timestamp: 0,
         };
         let second_entry = OracleEntry {
-            price: Price::new(2_000_000, 1_000),
+            price: Price::new(2_000, 1),
             volume: Volume::from_a_out_b_in(2_000_000, 1_000),
             liquidity: (2_000, 1).into(),
             timestamp: 0,
@@ -562,7 +568,7 @@ fn get_entry_works() {
         EmaOracle::on_finalize(1);
         System::set_block_number(100);
         let expected = AggregatedEntry {
-            price: Price::new(1_000, 500),
+            price: Price::new(2_000, 1_000),
             volume: Volume::default(), // volume for new blocks is zero by default
             liquidity: Liquidity::new(2_000, 1_000),
             oracle_age: 98,
@@ -570,7 +576,7 @@ fn get_entry_works() {
         assert_eq!(EmaOracle::get_entry(HDX, DOT, LastBlock, SOURCE), Ok(expected));
 
         let expected_ten_min = AggregatedEntry {
-            price: Price::new(1_000, 500),
+            price: Price::new(2_000, 1_000),
             volume: Volume::from_a_in_b_out(141, 70), // volume oracle gets updated towards zero
             liquidity: Liquidity::new(2_000, 1_000),
             oracle_age: 98,
@@ -578,7 +584,7 @@ fn get_entry_works() {
         assert_eq!(EmaOracle::get_entry(HDX, DOT, TenMinutes, SOURCE), Ok(expected_ten_min));
 
         let expected_day = AggregatedEntry {
-            price: Price::new(1_000, 500),
+            price: Price::new(2_000, 1_000),
             volume: Volume::from_a_in_b_out(986, 493),
             liquidity: Liquidity::new(2_000, 1_000),
             oracle_age: 98,
@@ -586,7 +592,7 @@ fn get_entry_works() {
         assert_eq!(EmaOracle::get_entry(HDX, DOT, Day, SOURCE), Ok(expected_day));
 
         let expected_week = AggregatedEntry {
-            price: Price::new(1_000, 500),
+            price: Price::new(2_000, 1_000),
             volume: Volume::from_a_in_b_out(998, 499),
             liquidity: Liquidity::new(2_000, 1_000),
             oracle_age: 98,

--- a/traits/src/oracle.rs
+++ b/traits/src/oracle.rs
@@ -30,6 +30,9 @@ where
 }
 
 /// Defines the different kinds of aggregation periods for oracles.
+///
+/// Note: Some of the oracles are named after certain periods of time.
+/// This description relies on the mapping of the enum to the internal implementation and can thus not be guaranteed.
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum OraclePeriod {
     /// The oracle data is from the last block, thus unaggregated.


### PR DESCRIPTION
This PR switches the oracle price calculation `on_trade` to use the liquidity instead of the trade amounts.