### PR TITLE
feat: liquidity mining with plugable price_adjustment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "hydradx-traits"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2857,6 +2857,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-arithmetic",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -5156,7 +5157,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquidity-mining"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "fixed",
  "frame-support",

--- a/liquidity-mining/Cargo.toml
+++ b/liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-liquidity-mining"
-version = "4.0.0"
+version = "4.1.0"
 description = "Liquidity mining"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/liquidity-mining/src/lib.rs
+++ b/liquidity-mining/src/lib.rs
@@ -104,9 +104,7 @@ use frame_support::{
     pallet_prelude::*,
     require_transactional,
     sp_runtime::{
-        traits::{
-            AccountIdConversion, AtLeast32BitUnsigned, BlockNumberProvider, MaybeSerializeDeserialize, One, Zero,
-        },
+        traits::{AccountIdConversion, BlockNumberProvider, MaybeSerializeDeserialize, One, Zero},
         RuntimeDebug,
     },
     traits::{Defensive, DefensiveOption},
@@ -175,7 +173,7 @@ pub mod pallet {
         type Event: From<Event<Self, I>> + IsType<<Self as frame_system::Config>::Event>;
 
         /// Asset type.
-        type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + MaxEncodedLen + AtLeast32BitUnsigned;
+        type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + MaxEncodedLen + Into<u32>;
 
         /// Currency for transfers.
         type MultiCurrency: MultiCurrency<Self::AccountId, CurrencyId = Self::AssetId, Balance = Balance>;

--- a/liquidity-mining/src/lib.rs
+++ b/liquidity-mining/src/lib.rs
@@ -104,7 +104,9 @@ use frame_support::{
     pallet_prelude::*,
     require_transactional,
     sp_runtime::{
-        traits::{AccountIdConversion, BlockNumberProvider, MaybeSerializeDeserialize, One, Zero},
+        traits::{
+            AccountIdConversion, AtLeast32BitUnsigned, BlockNumberProvider, MaybeSerializeDeserialize, One, Zero,
+        },
         RuntimeDebug,
     },
     traits::{Defensive, DefensiveOption},
@@ -173,7 +175,7 @@ pub mod pallet {
         type Event: From<Event<Self, I>> + IsType<<Self as frame_system::Config>::Event>;
 
         /// Asset type.
-        type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + MaxEncodedLen;
+        type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + MaxEncodedLen + AtLeast32BitUnsigned;
 
         /// Currency for transfers.
         type MultiCurrency: MultiCurrency<Self::AccountId, CurrencyId = Self::AssetId, Balance = Balance>;

--- a/liquidity-mining/src/lib.rs
+++ b/liquidity-mining/src/lib.rs
@@ -1746,6 +1746,32 @@ impl<T: Config<I>, I: 'static> hydradx_traits::liquidity_mining::Mutate<T::Accou
         )
     }
 
+    /// This function should be used when external source(e.g. oracle) is used for `price_adjustment`
+    /// or if `incentivized_asset` and `reward_currency` can't be different.
+    fn create_global_farm_without_price_adjustment(
+        total_rewards: Self::Balance,
+        planned_yielding_periods: Self::Period,
+        blocks_per_period: BlockNumberFor<T>,
+        incentivized_asset: T::AssetId,
+        reward_currency: T::AssetId,
+        owner: T::AccountId,
+        yield_per_period: Perquintill,
+        min_deposit: Self::Balance,
+    ) -> Result<(GlobalFarmId, Self::Balance), Self::Error> {
+        Self::create_global_farm(
+            total_rewards,
+            planned_yielding_periods,
+            blocks_per_period,
+            incentivized_asset,
+            reward_currency,
+            owner,
+            yield_per_period,
+            min_deposit,
+            //NOTE: `price_adjustment` == 1 is same as no `price_adjustment`
+            FixedU128::one(),
+        )
+    }
+
     fn update_global_farm_price_adjustment(
         who: T::AccountId,
         global_farm_id: GlobalFarmId,

--- a/liquidity-mining/src/lib.rs
+++ b/liquidity-mining/src/lib.rs
@@ -1532,7 +1532,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
         // Calculate reward for all periods since last update capped by balance of `GlobalFarm`
         // account.
-        let price_adjustment = T::PriceAdjustment::get(global_farm).unwrap();
+        let price_adjustment = T::PriceAdjustment::get(global_farm)?;
         let reward = math::calculate_global_farm_rewards(
             global_farm.total_shares_z,
             price_adjustment,

--- a/liquidity-mining/src/tests/lm_with_oracle.rs
+++ b/liquidity-mining/src/tests/lm_with_oracle.rs
@@ -1,0 +1,164 @@
+// This file is part of galacticcouncil/warehouse.
+
+// Copyright (C) 2020-2022  Intergalactic, Limited (GIB).
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use pretty_assertions::assert_eq;
+use test_ext::*;
+
+use crate::tests::mock::LiquidityMining3;
+
+//This test is using dummy oracle for price_adjustment. DummyOracle always returns .5 as
+//price_adjusment.
+#[test]
+fn non_full_farm_should_pay_rewards_with_half_speed_when_price_adjustmnet_is_from_dummy_oracle() {
+    new_test_ext().execute_with(|| {
+        let _ = with_transaction(|| {
+            const GLOBAL_FARM: GlobalFarmId = 1;
+            const YIELD_FARM_A: YieldFarmId = 2;
+            const YIELD_FARM_B: YieldFarmId = 3;
+
+            const ALICE_DEPOSIT: DepositId = 1;
+            const BOB_DEPOSIT: DepositId = 2;
+            const CHARLIE_DEPOSIT: DepositId = 3;
+
+            const TOTAL_REWARDS: u128 = 200_000 * ONE;
+
+            //initialize farms
+            set_block_number(100);
+            assert_ok!(LiquidityMining3::create_global_farm(
+                TOTAL_REWARDS,
+                20,
+                10,
+                BSX,
+                BSX,
+                GC,
+                Perquintill::from_float(0.5),
+                1_000,
+                One::one(),
+            ));
+
+            assert_ok!(LiquidityMining3::create_yield_farm(
+                GC,
+                GLOBAL_FARM,
+                FixedU128::from(2_u128),
+                None,
+                BSX_TKN1_AMM,
+                vec![BSX, TKN1],
+            ));
+
+            assert_ok!(LiquidityMining3::create_yield_farm(
+                GC,
+                GLOBAL_FARM,
+                FixedU128::from(1_u128),
+                None,
+                BSX_TKN2_AMM,
+                vec![BSX, TKN2],
+            ));
+
+            set_block_number(120);
+            //alice
+            assert_ok!(LiquidityMining3::deposit_lp_shares(
+                GLOBAL_FARM,
+                YIELD_FARM_A,
+                BSX_TKN1_AMM,
+                5_000 * ONE,
+                |_, _, _| { Ok(5_000 * ONE) }
+            ));
+
+            //bob
+            assert_ok!(LiquidityMining3::deposit_lp_shares(
+                GLOBAL_FARM,
+                YIELD_FARM_B,
+                BSX_TKN2_AMM,
+                2_500 * ONE,
+                |_, _, _| { Ok(2_500 * ONE) }
+            ));
+
+            //charlie
+            assert_ok!(LiquidityMining3::deposit_lp_shares(
+                GLOBAL_FARM,
+                YIELD_FARM_B,
+                BSX_TKN2_AMM,
+                2_500 * ONE,
+                |_, _, _| { Ok(2_500 * ONE) }
+            ));
+
+            set_block_number(401);
+
+            let alice_bsx_balance_0 = Tokens::free_balance(BSX, &ALICE);
+            let bob_bsx_balance_0 = Tokens::free_balance(BSX, &BOB);
+            let charlie_bsx_balance_0 = Tokens::free_balance(BSX, &CHARLIE);
+
+            let (_, _, _, unclaimable) =
+                LiquidityMining3::claim_rewards(ALICE, ALICE_DEPOSIT, YIELD_FARM_A, false).unwrap();
+            assert_eq!(unclaimable, 0);
+            assert_ok!(LiquidityMining3::withdraw_lp_shares(
+                ALICE_DEPOSIT,
+                YIELD_FARM_A,
+                unclaimable
+            ));
+
+            let (_, _, _, unclaimable) =
+                LiquidityMining3::claim_rewards(BOB, BOB_DEPOSIT, YIELD_FARM_B, false).unwrap();
+            assert_eq!(unclaimable, 0);
+            assert_ok!(LiquidityMining3::withdraw_lp_shares(
+                BOB_DEPOSIT,
+                YIELD_FARM_B,
+                unclaimable
+            ));
+
+            let (_, _, _, unclaimable) =
+                LiquidityMining3::claim_rewards(CHARLIE, CHARLIE_DEPOSIT, YIELD_FARM_B, false).unwrap();
+            assert_eq!(unclaimable, 0);
+            assert_ok!(LiquidityMining3::withdraw_lp_shares(
+                CHARLIE_DEPOSIT,
+                YIELD_FARM_B,
+                unclaimable
+            ));
+
+            let alice_claimed = Tokens::free_balance(BSX, &ALICE) - alice_bsx_balance_0;
+            let bob_claimed = Tokens::free_balance(BSX, &BOB) - bob_bsx_balance_0;
+            let charlie_claimed = Tokens::free_balance(BSX, &CHARLIE) - charlie_bsx_balance_0;
+
+            assert_eq!(alice_claimed, 70_000 * ONE);
+            assert_eq!(bob_claimed, 17_500 * ONE);
+            assert_eq!(charlie_claimed, 17_500 * ONE);
+
+            let claimed_total = alice_claimed + bob_claimed + charlie_claimed;
+
+            assert_eq!(claimed_total.abs_diff(TOTAL_REWARDS), 95_000 * ONE);
+
+            let yield_farm_a_claimed = alice_claimed;
+            let yield_farm_b_claimed = bob_claimed + charlie_claimed;
+
+            const TOLERANCE: u128 = 10;
+            assert!(
+                yield_farm_a_claimed.abs_diff(2 * yield_farm_b_claimed).le(&TOLERANCE),
+                "yield_farm_a_claimed == 2 * yield_farm_b_claimed"
+            );
+
+            assert!(
+                alice_claimed.abs_diff(4 * bob_claimed).le(&TOLERANCE),
+                "alice_claimed == 4 * bob_claimed"
+            );
+
+            assert_eq!(bob_claimed, charlie_claimed, "bob_claimed == charlie_claimed");
+
+            TransactionOutcome::Commit(DispatchResult::Ok(()))
+        });
+    });
+}

--- a/liquidity-mining/src/tests/mock.rs
+++ b/liquidity-mining/src/tests/mock.rs
@@ -127,6 +127,8 @@ frame_support::construct_runtime!(
         System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
         LiquidityMining: liq_mining::<Instance1>::{Pallet, Storage, Event<T>},
         LiquidityMining2: liq_mining::<Instance2>::{Pallet, Storage, Event<T>},
+        //This LM instance is using dummy oracle for price_adjustment
+        LiquidityMining3: liq_mining::<Instance3>::{Pallet, Storage, Event<T>},
         Tokens: orml_tokens::{Pallet, Call, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
     }
@@ -292,6 +294,7 @@ impl Config<Instance1> for Test {
     type MaxYieldFarmsPerGlobalFarm = MaxYieldFarmsPerGlobalFarm;
     type NonDustableWhitelistHandler = Whitelist;
     type AssetRegistry = AssetRegistry;
+    type PriceAdjustment = ();
 }
 
 parameter_types! {
@@ -315,6 +318,27 @@ impl Config<Instance2> for Test {
     type MaxYieldFarmsPerGlobalFarm = MaxYieldFarmsPerGlobalFarm;
     type NonDustableWhitelistHandler = Whitelist;
     type AssetRegistry = AssetRegistry;
+    type PriceAdjustment = ();
+}
+
+parameter_types! {
+    pub const LMPalletId3: PalletId = PalletId(*b"TEST_lm3");
+}
+
+impl Config<Instance3> for Test {
+    type Event = Event;
+    type AssetId = AssetId;
+    type MultiCurrency = Tokens;
+    type PalletId = LMPalletId3;
+    type MinPlannedYieldingPeriods = MinPlannedYieldingPeriods2;
+    type MinTotalFarmRewards = MinTotalFarmRewards;
+    type BlockNumberProvider = MockBlockNumberProvider;
+    type AmmPoolId = AccountId;
+    type MaxFarmEntriesPerDeposit = MaxEntriesPerDeposit;
+    type MaxYieldFarmsPerGlobalFarm = MaxYieldFarmsPerGlobalFarm;
+    type NonDustableWhitelistHandler = Whitelist;
+    type AssetRegistry = AssetRegistry;
+    type PriceAdjustment = DummyOraclePriceAdjustment;
 }
 
 parameter_types! {
@@ -349,6 +373,18 @@ impl orml_tokens::Config for Test {
     type OnNewTokenAccount = ();
     type MaxReserves = ConstU32<100_000>;
     type ReserveIdentifier = ();
+}
+
+pub struct DummyOraclePriceAdjustment;
+
+impl PriceAdjustment<GlobalFarmData<Test, Instance3>> for DummyOraclePriceAdjustment {
+    type Error = DispatchError;
+
+    type PriceAdjustment = FixedU128;
+
+    fn get(_global_farm: &GlobalFarmData<Test, Instance3>) -> Result<Self::PriceAdjustment, Self::Error> {
+        Ok(FixedU128::from_inner(500_000_000_000_000_000)) //0.5
+    }
 }
 
 pub struct Whitelist;

--- a/liquidity-mining/src/tests/mock.rs
+++ b/liquidity-mining/src/tests/mock.rs
@@ -18,8 +18,8 @@
 #![cfg(test)]
 use super::*;
 
-use crate as liq_mining;
 use crate::Config;
+use crate::{self as liq_mining, types::DefaultPriceAdjustment};
 use frame_support::{
     parameter_types,
     traits::Contains,
@@ -294,7 +294,7 @@ impl Config<Instance1> for Test {
     type MaxYieldFarmsPerGlobalFarm = MaxYieldFarmsPerGlobalFarm;
     type NonDustableWhitelistHandler = Whitelist;
     type AssetRegistry = AssetRegistry;
-    type PriceAdjustment = ();
+    type PriceAdjustment = DefaultPriceAdjustment;
 }
 
 parameter_types! {
@@ -318,7 +318,7 @@ impl Config<Instance2> for Test {
     type MaxYieldFarmsPerGlobalFarm = MaxYieldFarmsPerGlobalFarm;
     type NonDustableWhitelistHandler = Whitelist;
     type AssetRegistry = AssetRegistry;
-    type PriceAdjustment = ();
+    type PriceAdjustment = DefaultPriceAdjustment;
 }
 
 parameter_types! {

--- a/liquidity-mining/src/tests/mod.rs
+++ b/liquidity-mining/src/tests/mod.rs
@@ -261,6 +261,7 @@ pub mod terminate_global_farm;
 pub mod terminate_yield_farm;
 pub mod test_ext;
 
+pub mod lm_with_oracle;
 #[allow(clippy::module_inception)]
 pub mod tests;
 pub mod update_global_farm;

--- a/liquidity-mining/src/types.rs
+++ b/liquidity-mining/src/types.rs
@@ -17,12 +17,26 @@
 
 use super::*;
 
-use hydradx_traits::liquidity_mining::DefaultPriceAdjustment;
+use hydradx_traits::liquidity_mining::PriceAdjustment;
 pub use hydradx_traits::liquidity_mining::{DepositId, GlobalFarmId, YieldFarmId};
 
 pub type FarmId = u32;
 pub type Balance = u128;
 pub type FarmMultiplier = FixedU128;
+
+/// Default implementation of `PriceAdjustment` trait which returns `price_adjustment` value saved
+/// in `GlobalFarm`.
+pub struct DefaultPriceAdjustment;
+
+impl<T: Config<I>, I: 'static> PriceAdjustment<GlobalFarmData<T, I>> for DefaultPriceAdjustment {
+    type Error = DispatchError;
+
+    type PriceAdjustment = FixedU128;
+
+    fn get(global_farm: &GlobalFarmData<T, I>) -> Result<Self::PriceAdjustment, Self::Error> {
+        Ok(global_farm.price_adjustment)
+    }
+}
 
 /// This struct represents the state a of single liquidity mining program. `YieldFarm`s are rewarded from
 /// `GlobalFarm` based on their stake in `GlobalFarm`. `YieldFarm` stake in `GlobalFarm` is derived from
@@ -54,12 +68,6 @@ pub struct GlobalFarmData<T: Config<I>, I: 'static = ()> {
     pub(super) total_yield_farms_count: u32,
     pub(super) price_adjustment: FixedU128,
     pub(super) state: FarmState,
-}
-
-impl<T: Config<I>, I: 'static> DefaultPriceAdjustment<FixedU128> for GlobalFarmData<T, I> {
-    fn get_price_adjustment(&self) -> FixedU128 {
-        self.price_adjustment
-    }
 }
 
 impl<T: Config<I>, I: 'static> GlobalFarmData<T, I> {

--- a/liquidity-mining/src/types.rs
+++ b/liquidity-mining/src/types.rs
@@ -17,6 +17,7 @@
 
 use super::*;
 
+use hydradx_traits::liquidity_mining::DefaultPriceAdjustment;
 pub use hydradx_traits::liquidity_mining::{DepositId, GlobalFarmId, YieldFarmId};
 
 pub type FarmId = u32;
@@ -31,18 +32,18 @@ pub type FarmMultiplier = FixedU128;
 #[codec(mel_bound())]
 #[scale_info(skip_type_params(T, I))]
 pub struct GlobalFarmData<T: Config<I>, I: 'static = ()> {
-    pub(super) id: GlobalFarmId,
+    pub id: GlobalFarmId,
     pub(super) owner: T::AccountId,
     pub(super) updated_at: PeriodOf<T>,
     pub(super) total_shares_z: Balance,
     pub(super) accumulated_rpz: FixedU128,
-    pub(super) reward_currency: T::AssetId,
+    pub reward_currency: T::AssetId,
     pub(super) pending_rewards: Balance,
     pub(super) accumulated_paid_rewards: Balance,
     pub(super) yield_per_period: Perquintill,
     pub(super) planned_yielding_periods: PeriodOf<T>,
     pub(super) blocks_per_period: BlockNumberFor<T>,
-    pub(super) incentivized_asset: T::AssetId,
+    pub incentivized_asset: T::AssetId,
     pub(super) max_reward_per_period: Balance,
     // min. LP shares user must deposit to start yield farming.
     pub(super) min_deposit: Balance,
@@ -53,6 +54,12 @@ pub struct GlobalFarmData<T: Config<I>, I: 'static = ()> {
     pub(super) total_yield_farms_count: u32,
     pub(super) price_adjustment: FixedU128,
     pub(super) state: FarmState,
+}
+
+impl<T: Config<I>, I: 'static> DefaultPriceAdjustment<FixedU128> for GlobalFarmData<T, I> {
+    fn get_price_adjustment(&self) -> FixedU128 {
+        self.price_adjustment
+    }
 }
 
 impl<T: Config<I>, I: 'static> GlobalFarmData<T, I> {

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydradx-traits"
-version = "2.1.0"
+version = "2.2.0"
 description = "Shared traits"
 authors = ["GalacticCouncil"]
 edition = "2021"
@@ -13,6 +13,7 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 serde = { features = ["derive"], optional = true, version = "1.0.137" }
 impl-trait-for-tuples = "0.2.2"
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }

--- a/traits/src/liquidity_mining.rs
+++ b/traits/src/liquidity_mining.rs
@@ -173,21 +173,3 @@ pub trait PriceAdjustment<GlobalFarm> {
     /// Returns value of `PriceAdjustment` for given `GlobalFarm`.
     fn get(global_farm: &GlobalFarm) -> Result<Self::PriceAdjustment, Self::Error>;
 }
-
-/// Implementers of this trait provide `price_adjustment` from `self`.
-pub trait DefaultPriceAdjustment<Price> {
-    fn get_price_adjustment(&self) -> Price;
-}
-
-/// Default implementation of PriceAdjustment trait that returns value from `GlobalFarm`.
-impl<GlobalFarm> PriceAdjustment<GlobalFarm> for ()
-where
-    GlobalFarm: DefaultPriceAdjustment<FixedU128>,
-{
-    type Error = sp_runtime::DispatchError;
-    type PriceAdjustment = FixedU128;
-
-    fn get(global_farm: &GlobalFarm) -> Result<Self::PriceAdjustment, Self::Error> {
-        Ok(global_farm.get_price_adjustment())
-    }
-}

--- a/traits/src/liquidity_mining.rs
+++ b/traits/src/liquidity_mining.rs
@@ -30,6 +30,21 @@ pub trait Mutate<AccountId, AssetId, BlockNumber> {
         price_adjustment: FixedU128,
     ) -> Result<(YieldFarmId, Self::Balance), Self::Error>;
 
+    /// Create new global farm without `price_adjustment`.
+    ///
+    /// Returns: `(GlobalFarmId, max reward per period)`
+    #[allow(clippy::too_many_arguments)]
+    fn create_global_farm_without_price_adjustment(
+        total_rewards: Self::Balance,
+        planned_yielding_periods: Self::Period,
+        blocks_per_period: BlockNumber,
+        incentivized_asset: AssetId,
+        reward_currency: AssetId,
+        owner: AccountId,
+        yield_per_period: Perquintill,
+        min_deposit: Self::Balance,
+    ) -> Result<(YieldFarmId, Self::Balance), Self::Error>;
+
     /// Update price adjustment of the existing global farm.
     fn update_global_farm_price_adjustment(
         who: AccountId,

--- a/traits/src/liquidity_mining.rs
+++ b/traits/src/liquidity_mining.rs
@@ -149,3 +149,30 @@ pub trait Mutate<AccountId, AssetId, BlockNumber> {
     /// Returns `Some(global_farm_id)` for given `deposit_id` and `yield_farm_id` or `None`.
     fn get_global_farm_id(deposit_id: DepositId, yield_farm_id: YieldFarmId) -> Option<u32>;
 }
+
+pub trait DefaultPriceAdjustment<Price> {
+    fn get_price_adjustment(&self) -> Price;
+}
+
+pub trait PriceAdjustment<GlobalFarm>
+where
+    GlobalFarm: DefaultPriceAdjustment<Self::PriceAdjustment>,
+{
+    type Error;
+    type PriceAdjustment;
+
+    /// Returns value of `PriceAdjustment` for given `GlobalFarm`.
+    fn get(global_farm: &GlobalFarm) -> Result<Self::PriceAdjustment, Self::Error>;
+}
+
+impl<GlobalFarm> PriceAdjustment<GlobalFarm> for ()
+where
+    GlobalFarm: DefaultPriceAdjustment<FixedU128>,
+{
+    type Error = sp_runtime::DispatchError;
+    type PriceAdjustment = FixedU128;
+
+    fn get(global_farm: &GlobalFarm) -> Result<Self::PriceAdjustment, Self::Error> {
+        Ok(global_farm.get_price_adjustment())
+    }
+}

--- a/traits/src/liquidity_mining.rs
+++ b/traits/src/liquidity_mining.rs
@@ -150,14 +150,8 @@ pub trait Mutate<AccountId, AssetId, BlockNumber> {
     fn get_global_farm_id(deposit_id: DepositId, yield_farm_id: YieldFarmId) -> Option<u32>;
 }
 
-pub trait DefaultPriceAdjustment<Price> {
-    fn get_price_adjustment(&self) -> Price;
-}
-
-pub trait PriceAdjustment<GlobalFarm>
-where
-    GlobalFarm: DefaultPriceAdjustment<Self::PriceAdjustment>,
-{
+/// Implementers of this trait provide `price_adjustment` for given `GlobalFarm`.
+pub trait PriceAdjustment<GlobalFarm> {
     type Error;
     type PriceAdjustment;
 
@@ -165,6 +159,12 @@ where
     fn get(global_farm: &GlobalFarm) -> Result<Self::PriceAdjustment, Self::Error>;
 }
 
+/// Implementers of this trait provide `price_adjustment` from `self`.
+pub trait DefaultPriceAdjustment<Price> {
+    fn get_price_adjustment(&self) -> Price;
+}
+
+/// Default implementation of PriceAdjustment trait that returns value from `GlobalFarm`.
 impl<GlobalFarm> PriceAdjustment<GlobalFarm> for ()
 where
     GlobalFarm: DefaultPriceAdjustment<FixedU128>,


### PR DESCRIPTION
This PR is adding ability to plug external source for `price_adjustment` or use `price_adjustment` stored in global-farm.
 
In this PR we are adding new trait `PriceAdjustment` with default implementation for `()` which provide `price_adjustment` same way as before.

Why:
On HydraDX we want to use oracle price for `price_adjustment` and on Basilisk we are using value stored in global-farm.

This PR is partial fix for: https://github.com/galacticcouncil/HydraDX-node/issues/529