### PR TITLE
Feat:LM price_adjustment fallback when oracle is not available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5157,7 +5157,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquidity-mining"
-version = "4.1.3"
+version = "4.2.0"
 dependencies = [
  "fixed",
  "frame-support",

--- a/liquidity-mining/Cargo.toml
+++ b/liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-liquidity-mining"
-version = "4.1.3"
+version = "4.2.0"
 description = "Liquidity mining"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/liquidity-mining/src/lib.rs
+++ b/liquidity-mining/src/lib.rs
@@ -1530,12 +1530,16 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         )
         .map_err(|_| ArithmeticError::Overflow)?;
 
+        if let Ok(price_adjustment) = T::PriceAdjustment::get(global_farm) {
+            global_farm.price_adjustment = price_adjustment;
+        }
+
         // Calculate reward for all periods since last update capped by balance of `GlobalFarm`
         // account.
-        let price_adjustment = T::PriceAdjustment::get(global_farm)?;
         let reward = math::calculate_global_farm_rewards(
             global_farm.total_shares_z,
-            price_adjustment,
+            //NOTE: Fallback. Last saved value should be used if oracle is not available.
+            global_farm.price_adjustment,
             global_farm.yield_per_period.into(),
             global_farm.max_reward_per_period,
             periods_since_last_update,

--- a/liquidity-mining/src/tests/lm_with_oracle.rs
+++ b/liquidity-mining/src/tests/lm_with_oracle.rs
@@ -162,3 +162,137 @@ fn non_full_farm_should_pay_rewards_with_half_speed_when_price_adjustmnet_is_fro
         });
     });
 }
+
+#[test]
+fn oracles_price_adjustment_should_be_used_and_saved_when_oracle_is_available() {
+    new_test_ext().execute_with(|| {
+        let _ = with_transaction(|| {
+            const GLOBAL_FARM: GlobalFarmId = 1;
+            const YIELD_FARM_A: YieldFarmId = 2;
+
+            const ALICE_DEPOSIT: DepositId = 1;
+
+            const TOTAL_REWARDS: u128 = 200_000 * ONE;
+
+            //Arrange
+            set_block_number(100);
+            assert_ok!(LiquidityMining3::create_global_farm(
+                TOTAL_REWARDS,
+                20,
+                10,
+                BSX,
+                BSX,
+                GC,
+                Perquintill::from_float(0.5),
+                1_000,
+                FixedU128::from_float(5.5_f64), //default price_adjustment, won't be used.
+            ));
+
+            assert_ok!(LiquidityMining3::create_yield_farm(
+                GC,
+                GLOBAL_FARM,
+                FixedU128::from(2_u128),
+                None,
+                BSX_TKN1_AMM,
+                vec![BSX, TKN1],
+            ));
+
+            set_block_number(120);
+            //alice
+            assert_ok!(LiquidityMining3::deposit_lp_shares(
+                GLOBAL_FARM,
+                YIELD_FARM_A,
+                BSX_TKN1_AMM,
+                5_000 * ONE,
+                |_, _, _| { Ok(5_000 * ONE) }
+            ));
+
+            //Act
+            set_block_number(401);
+            let (_, _, claimed_amount, unclaimable) =
+                LiquidityMining3::claim_rewards(ALICE, ALICE_DEPOSIT, YIELD_FARM_A, false).unwrap();
+
+            //Assert
+            assert_eq!(unclaimable, 0);
+            assert_eq!(claimed_amount, 70_000 * ONE);
+            //NOTE: global-farm's price_adjustment should be updated
+            assert_eq!(
+                LiquidityMining3::global_farm(GLOBAL_FARM).unwrap().price_adjustment,
+                FixedU128::from_float(0.5_f64)
+            );
+
+            TransactionOutcome::Commit(DispatchResult::Ok(()))
+        });
+    });
+}
+
+#[test]
+fn last_saved_price_adjustment_should_be_used_when_oracle_is_not_available() {
+    new_test_ext().execute_with(|| {
+        let _ = with_transaction(|| {
+            const GLOBAL_FARM: GlobalFarmId = 1;
+            const YIELD_FARM_A: YieldFarmId = 2;
+
+            const ALICE_DEPOSIT: DepositId = 1;
+
+            const TOTAL_REWARDS: u128 = 200_000 * ONE;
+
+            //Arrange
+            set_block_number(100);
+            assert_ok!(LiquidityMining3::create_global_farm(
+                TOTAL_REWARDS,
+                20,
+                1,
+                BSX,
+                BSX,
+                GC,
+                Perquintill::from_float(0.5),
+                1_000,
+                FixedU128::from(2_u128), //default price_adjustment, won't be used.
+            ));
+
+            assert_ok!(LiquidityMining3::create_yield_farm(
+                GC,
+                GLOBAL_FARM,
+                FixedU128::one(),
+                None,
+                BSX_TKN1_AMM,
+                vec![BSX, TKN1],
+            ));
+
+            //NOTE: This is special period. Oracle will fail if global-farm was updated in this
+            //period.
+            set_block_number(999_666_333);
+            //alice
+            assert_ok!(LiquidityMining3::deposit_lp_shares(
+                GLOBAL_FARM,
+                YIELD_FARM_A,
+                BSX_TKN1_AMM,
+                5_000 * ONE,
+                |_, _, _| { Ok(5_000 * ONE) }
+            ));
+
+            assert_eq!(
+                LiquidityMining3::global_farm(GLOBAL_FARM).unwrap().price_adjustment,
+                FixedU128::from(2_u128)
+            );
+            //Act
+            set_block_number(999_666_334);
+            //NOTE: Oracle will fail because global_farm.updated_at == 999_666_333 when oracle is
+            //called.
+            let (_, _, claimed_amount, unclaimable) =
+                LiquidityMining3::claim_rewards(ALICE, ALICE_DEPOSIT, YIELD_FARM_A, false).unwrap();
+
+            //Assert
+            assert_eq!(unclaimable, 0);
+            assert_eq!(claimed_amount, 5_000 * ONE);
+            //NOTE: global-farm's price_adjustment should be updated
+            assert_eq!(
+                LiquidityMining3::global_farm(GLOBAL_FARM).unwrap().price_adjustment,
+                FixedU128::from(2_u128)
+            );
+
+            TransactionOutcome::Commit(DispatchResult::Ok(()))
+        });
+    });
+}

--- a/liquidity-mining/src/tests/lm_with_oracle.rs
+++ b/liquidity-mining/src/tests/lm_with_oracle.rs
@@ -248,7 +248,7 @@ fn last_saved_price_adjustment_should_be_used_when_oracle_is_not_available() {
                 GC,
                 Perquintill::from_float(0.5),
                 1_000,
-                FixedU128::from(2_u128), //default price_adjustment, won't be used.
+                FixedU128::from(2_u128), //default price_adjustment
             ));
 
             assert_ok!(LiquidityMining3::create_yield_farm(
@@ -286,7 +286,7 @@ fn last_saved_price_adjustment_should_be_used_when_oracle_is_not_available() {
             //Assert
             assert_eq!(unclaimable, 0);
             assert_eq!(claimed_amount, 5_000 * ONE);
-            //NOTE: global-farm's price_adjustment should be updated
+            //NOTE: oracle is not available so value should not change.
             assert_eq!(
                 LiquidityMining3::global_farm(GLOBAL_FARM).unwrap().price_adjustment,
                 FixedU128::from(2_u128)

--- a/liquidity-mining/src/tests/mock.rs
+++ b/liquidity-mining/src/tests/mock.rs
@@ -382,8 +382,15 @@ impl PriceAdjustment<GlobalFarmData<Test, Instance3>> for DummyOraclePriceAdjust
 
     type PriceAdjustment = FixedU128;
 
-    fn get(_global_farm: &GlobalFarmData<Test, Instance3>) -> Result<Self::PriceAdjustment, Self::Error> {
-        Ok(FixedU128::from_inner(500_000_000_000_000_000)) //0.5
+    fn get(global_farm: &GlobalFarmData<Test, Instance3>) -> Result<Self::PriceAdjustment, Self::Error> {
+        //This is special case to test global-fram's fallback when oracle is not available.
+        if global_farm.updated_at == 999_666_333 {
+            Err(sp_runtime::DispatchError::Other(
+                "Oracle is not available - updated_at == 999_666_333 is special case.",
+            ))
+        } else {
+            Ok(FixedU128::from_inner(500_000_000_000_000_000)) //0.5
+        }
     }
 }
 


### PR DESCRIPTION
This PR implements fallback for liquidity-mining `price_adjustment` when oracle is not  available.
We are saving last value of `price_adjustment` from oracle in the `GlobalFarm` and if oracle is not available this last saved value should be used instead of error.