### PR TITLE
fix: multicurrency payment fee rouding

### DIFF
--- a/transaction-multi-payment/src/mock.rs
+++ b/transaction-multi-payment/src/mock.rs
@@ -53,6 +53,7 @@ pub const SUPPORTED_CURRENCY_WITH_PRICE: AssetId = 3000;
 pub const UNSUPPORTED_CURRENCY: AssetId = 4000;
 pub const SUPPORTED_CURRENCY_NO_BALANCE: AssetId = 5000; // Used for insufficient balance testing
 pub const HIGH_ED_CURRENCY: AssetId = 6000;
+pub const HIGH_VALUE_CURRENCY: AssetId = 7000;
 
 pub const HIGH_ED: Balance = 5;
 
@@ -212,6 +213,7 @@ parameter_type_with_key! {
     pub ExistentialDeposits: |currency_id: AssetId| -> Balance {
         match currency_id {
             &HIGH_ED_CURRENCY => HIGH_ED,
+            &HIGH_VALUE_CURRENCY => 1u128,
             _ => 2u128
         }
     };
@@ -319,6 +321,7 @@ impl ExtBuilder {
                 (SUPPORTED_CURRENCY, Price::from_float(1.5)),
                 (SUPPORTED_CURRENCY_WITH_PRICE, Price::from_float(0.5)),
                 (HIGH_ED_CURRENCY, Price::from(3)),
+                (HIGH_VALUE_CURRENCY, Price::from_inner(100)),
             ],
             account_currencies: self.account_currencies,
         }

--- a/transaction-multi-payment/src/mock.rs
+++ b/transaction-multi-payment/src/mock.rs
@@ -211,9 +211,9 @@ impl SpotPriceProvider<AssetId> for SpotPrice {
 
 parameter_type_with_key! {
     pub ExistentialDeposits: |currency_id: AssetId| -> Balance {
-        match currency_id {
-            &HIGH_ED_CURRENCY => HIGH_ED,
-            &HIGH_VALUE_CURRENCY => 1u128,
+        match *currency_id {
+            HIGH_ED_CURRENCY => HIGH_ED,
+            HIGH_VALUE_CURRENCY => 1u128,
             _ => 2u128
         }
     };

--- a/transaction-multi-payment/src/tests.rs
+++ b/transaction-multi-payment/src/tests.rs
@@ -216,35 +216,30 @@ fn fee_payment_in_non_native_currency() {
 
 #[test]
 fn fee_payment_in_expensive_non_native_currency_should_be_non_zero() {
-    const CHARLIE: AccountId = 5;
-
     ExtBuilder::default()
         .base_weight(5)
-        .account_tokens(CHARLIE, HIGH_VALUE_CURRENCY, 10_000)
-        .with_currencies(vec![(CHARLIE, HIGH_VALUE_CURRENCY)])
+        .account_tokens(BOB, HIGH_VALUE_CURRENCY, 10_000)
+        .with_currencies(vec![(BOB, HIGH_VALUE_CURRENCY)])
         .build()
         .execute_with(|| {
-            // Make sure Charlie ain't got a penny!
-            assert_eq!(Balances::free_balance(CHARLIE), 0);
-
-            let len = 1000;
+            let len = 100;
             let info = info_from_weight(Weight::from_ref_time(5));
 
-            assert_eq!(Tokens::free_balance(HIGH_VALUE_CURRENCY, &CHARLIE), 10_000);
+            assert_eq!(Tokens::free_balance(HIGH_VALUE_CURRENCY, &BOB), 10_000);
 
             let pre = ChargeTransactionPayment::<Test>::from(0)
-                .pre_dispatch(&CHARLIE, CALL, &info, len)
+                .pre_dispatch(&BOB, CALL, &info, len)
                 .unwrap();
 
-            // Charlie should be charged at least 1 token
-            assert_eq!(Tokens::free_balance(HIGH_VALUE_CURRENCY, &CHARLIE), 9999);
+            // Bob should be charged at least 1 token
+            assert_eq!(Tokens::free_balance(HIGH_VALUE_CURRENCY, &BOB), 9999);
 
             let post_info = post_info_from_weight(Weight::from_ref_time(3));
             assert!(
                 ChargeTransactionPayment::<Test>::post_dispatch(Some(pre), &info, &post_info, len, &Ok(())).is_ok()
             );
-            // Charlie should not be refunded in case he payed only 1 token
-            assert_eq!(Tokens::free_balance(HIGH_VALUE_CURRENCY, &CHARLIE), 9999);
+            // BOB should not be refunded in case he payed only 1 token
+            assert_eq!(Tokens::free_balance(HIGH_VALUE_CURRENCY, &BOB), 9999);
         });
 }
 

--- a/transaction-multi-payment/src/tests.rs
+++ b/transaction-multi-payment/src/tests.rs
@@ -215,7 +215,7 @@ fn fee_payment_in_non_native_currency() {
 }
 
 #[test]
-fn fee_payment_in_expensive_non_native_currency() {
+fn fee_payment_in_expensive_non_native_currency_should_be_non_zero() {
     const CHARLIE: AccountId = 5;
 
     ExtBuilder::default()


### PR DESCRIPTION
This PR ensures that a non-zero fee is charged even if the calculated fee in the native currency is small and the non-native fee currency is expensive (low price value).